### PR TITLE
feat(issue-03): 感情解析 API Routes と Hume AI 連携を実装

### DIFF
--- a/__tests__/api/analyzeFace.test.ts
+++ b/__tests__/api/analyzeFace.test.ts
@@ -1,0 +1,152 @@
+/**
+ * app/api/analyze-face/route.ts のテスト
+ * API Route の正常系・異常系レスポンスを検証する
+ */
+
+import { NextRequest } from 'next/server';
+
+// 環境変数をモック
+const VALID_ENV = {
+  HUME_API_KEY: 'test-api-key',
+  HUME_SECRET_KEY: 'test-secret-key',
+};
+
+// lib/hume.ts の analyzeFace をモック
+jest.mock('../../lib/hume', () => ({
+  analyzeFace: jest.fn(),
+}));
+
+import { analyzeFace as mockAnalyzeFace } from '../../lib/hume';
+import { POST } from '../../app/api/analyze-face/route';
+
+const mockedAnalyzeFace = mockAnalyzeFace as jest.MockedFunction<typeof mockAnalyzeFace>;
+
+// テスト用の JSON リクエスト（Base64 画像データを模擬）
+const makeJsonRequest = (hasImage = true): NextRequest => {
+  const body = hasImage
+    ? JSON.stringify({ image: 'data:image/jpeg;base64,/9j/fakebase64==' })
+    : JSON.stringify({});
+  return new NextRequest('http://localhost/api/analyze-face', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+};
+
+describe('POST /api/analyze-face', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('環境変数未設定時', () => {
+    it('HUME_API_KEY が未設定なら 400 を返す', async () => {
+      const originalKey = process.env.HUME_API_KEY;
+      delete process.env.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+
+      const req = makeJsonRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+      expect(JSON.stringify(body)).not.toContain('test-api-key');
+      expect(JSON.stringify(body)).not.toContain('test-secret-key');
+
+      process.env.HUME_API_KEY = originalKey;
+    });
+
+    it('HUME_SECRET_KEY が未設定なら 400 を返す', async () => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      const originalSecret = process.env.HUME_SECRET_KEY;
+      delete process.env.HUME_SECRET_KEY;
+
+      const req = makeJsonRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+
+      process.env.HUME_SECRET_KEY = originalSecret;
+    });
+  });
+
+  describe('リクエストバリデーション', () => {
+    it('image フィールドがない場合は 422 を返す', async () => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+
+      const req = makeJsonRequest(false);
+      const res = await POST(req);
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('正常系', () => {
+    beforeEach(() => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+    });
+
+    it('Hume AI の解析結果を EmotionScore 形式で返す', async () => {
+      const mockScore = {
+        ANGRY: 0.05,
+        ANXIOUS: 0.1,
+        HAPPY: 0.6,
+        NEUTRAL: 0.15,
+        STRESSED: 0.05,
+        HIDING: 0.05,
+      };
+      mockedAnalyzeFace.mockResolvedValueOnce(mockScore);
+
+      const req = makeJsonRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('score');
+      expect(body.score).toEqual(mockScore);
+    });
+
+    it('レスポンスボディに機密値が含まれない', async () => {
+      const mockScore = {
+        ANGRY: 0,
+        ANXIOUS: 0,
+        HAPPY: 1,
+        NEUTRAL: 0,
+        STRESSED: 0,
+        HIDING: 0,
+      };
+      mockedAnalyzeFace.mockResolvedValueOnce(mockScore);
+
+      const req = makeJsonRequest();
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(JSON.stringify(body)).not.toContain('test-api-key');
+      expect(JSON.stringify(body)).not.toContain('test-secret-key');
+    });
+  });
+
+  describe('異常系（Hume AI エラー）', () => {
+    beforeEach(() => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+    });
+
+    it('Hume AI がエラーを返した場合は 502 を返す', async () => {
+      mockedAnalyzeFace.mockRejectedValueOnce(new Error('Hume API error'));
+
+      const req = makeJsonRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+    });
+  });
+});

--- a/__tests__/api/analyzeVoice.test.ts
+++ b/__tests__/api/analyzeVoice.test.ts
@@ -1,0 +1,154 @@
+/**
+ * app/api/analyze-voice/route.ts のテスト
+ * API Route の正常系・異常系レスポンスを検証する
+ */
+
+import { NextRequest } from 'next/server';
+
+// 環境変数をモック
+const VALID_ENV = {
+  HUME_API_KEY: 'test-api-key',
+  HUME_SECRET_KEY: 'test-secret-key',
+};
+
+// lib/hume.ts の analyzeVoice をモック
+jest.mock('../../lib/hume', () => ({
+  analyzeVoice: jest.fn(),
+}));
+
+import { analyzeVoice as mockAnalyzeVoice } from '../../lib/hume';
+import { POST } from '../../app/api/analyze-voice/route';
+
+const mockedAnalyzeVoice = mockAnalyzeVoice as jest.MockedFunction<typeof mockAnalyzeVoice>;
+
+// テスト用の FormData（音声バイナリを模擬）
+const makeFormDataRequest = (hasAudio = true): NextRequest => {
+  const formData = new FormData();
+  if (hasAudio) {
+    const audioBlob = new Blob(['fake-audio-data'], { type: 'audio/webm' });
+    formData.append('audio', audioBlob, 'audio.webm');
+  }
+  return new NextRequest('http://localhost/api/analyze-voice', {
+    method: 'POST',
+    body: formData,
+  });
+};
+
+describe('POST /api/analyze-voice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('環境変数未設定時', () => {
+    it('HUME_API_KEY が未設定なら 400 を返す', async () => {
+      const originalKey = process.env.HUME_API_KEY;
+      delete process.env.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+
+      const req = makeFormDataRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+      // エラーメッセージに機密値が含まれないことを確認
+      expect(JSON.stringify(body)).not.toContain('test-api-key');
+      expect(JSON.stringify(body)).not.toContain('test-secret-key');
+
+      process.env.HUME_API_KEY = originalKey;
+    });
+
+    it('HUME_SECRET_KEY が未設定なら 400 を返す', async () => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      const originalSecret = process.env.HUME_SECRET_KEY;
+      delete process.env.HUME_SECRET_KEY;
+
+      const req = makeFormDataRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+
+      process.env.HUME_SECRET_KEY = originalSecret;
+    });
+  });
+
+  describe('リクエストバリデーション', () => {
+    it('audio フィールドがない場合は 422 を返す', async () => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+
+      const req = makeFormDataRequest(false);
+      const res = await POST(req);
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('正常系', () => {
+    beforeEach(() => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+    });
+
+    it('Hume AI の解析結果を EmotionScore 形式で返す', async () => {
+      const mockScore = {
+        ANGRY: 0.1,
+        ANXIOUS: 0.2,
+        HAPPY: 0.3,
+        NEUTRAL: 0.2,
+        STRESSED: 0.1,
+        HIDING: 0.1,
+      };
+      mockedAnalyzeVoice.mockResolvedValueOnce(mockScore);
+
+      const req = makeFormDataRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('score');
+      expect(body.score).toEqual(mockScore);
+    });
+
+    it('レスポンスボディに機密値が含まれない', async () => {
+      const mockScore = {
+        ANGRY: 0,
+        ANXIOUS: 0,
+        HAPPY: 1,
+        NEUTRAL: 0,
+        STRESSED: 0,
+        HIDING: 0,
+      };
+      mockedAnalyzeVoice.mockResolvedValueOnce(mockScore);
+
+      const req = makeFormDataRequest();
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(JSON.stringify(body)).not.toContain('test-api-key');
+      expect(JSON.stringify(body)).not.toContain('test-secret-key');
+    });
+  });
+
+  describe('異常系（Hume AI エラー）', () => {
+    beforeEach(() => {
+      process.env.HUME_API_KEY = VALID_ENV.HUME_API_KEY;
+      process.env.HUME_SECRET_KEY = VALID_ENV.HUME_SECRET_KEY;
+    });
+
+    it('Hume AI がエラーを返した場合は 502 を返す', async () => {
+      mockedAnalyzeVoice.mockRejectedValueOnce(new Error('Hume API error'));
+
+      const req = makeFormDataRequest();
+      const res = await POST(req);
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+    });
+  });
+});

--- a/__tests__/lib/hume.test.ts
+++ b/__tests__/lib/hume.test.ts
@@ -1,0 +1,182 @@
+/**
+ * lib/hume.ts の Hume AI 接続ロジックテスト
+ * fetch をモックして外部 API 呼び出しを検証する
+ */
+
+// グローバル fetch をモック
+global.fetch = jest.fn();
+
+import { analyzeVoice, analyzeFace } from '../../lib/hume';
+
+const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+// Hume AI のレスポンス形式に近いモック（音声解析）
+const makeVoiceResponse = (predictions: Array<{ name: string; score: number }>) => ({
+  ok: true,
+  json: async () => ({
+    results: {
+      predictions: [
+        {
+          models: {
+            prosody: {
+              grouped_predictions: [
+                {
+                  predictions: predictions.map((p) => ({
+                    emotions: [p],
+                  })),
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  }),
+});
+
+// Hume AI のレスポンス形式に近いモック（表情解析）
+const makeFaceResponse = (predictions: Array<{ name: string; score: number }>) => ({
+  ok: true,
+  json: async () => ({
+    results: {
+      predictions: [
+        {
+          models: {
+            face: {
+              grouped_predictions: [
+                {
+                  predictions: predictions.map((p) => ({
+                    emotions: [p],
+                  })),
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  }),
+});
+
+// エラーレスポンス
+const makeErrorResponse = (status: number) => ({
+  ok: false,
+  status,
+  json: async () => ({ message: 'API Error' }),
+});
+
+describe('analyzeVoice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.HUME_API_KEY = 'test-api-key';
+    process.env.HUME_SECRET_KEY = 'test-secret-key';
+  });
+
+  it('正常系：EmotionScore 形式のオブジェクトを返す', async () => {
+    mockFetch.mockResolvedValueOnce(makeVoiceResponse([
+      { name: 'Anger', score: 0.8 },
+      { name: 'Anxiety', score: 0.1 },
+      { name: 'Joy', score: 0.05 },
+      { name: 'Calmness', score: 0.03 },
+      { name: 'Stress', score: 0.01 },
+      { name: 'Contempt', score: 0.01 },
+    ]) as unknown as Response);
+
+    const audioData = new Uint8Array([0, 1, 2]).buffer;
+    const result = await analyzeVoice(audioData);
+
+    expect(result).toHaveProperty('ANGRY');
+    expect(result).toHaveProperty('ANXIOUS');
+    expect(result).toHaveProperty('HAPPY');
+    expect(result).toHaveProperty('NEUTRAL');
+    expect(result).toHaveProperty('STRESSED');
+    expect(result).toHaveProperty('HIDING');
+
+    // 各値が 0〜1 の範囲内
+    Object.values(result).forEach((v) => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('合計スコアが 1 になるよう正規化されている', async () => {
+    mockFetch.mockResolvedValueOnce(makeVoiceResponse([
+      { name: 'Anger', score: 2.0 },
+      { name: 'Joy', score: 2.0 },
+    ]) as unknown as Response);
+
+    const audioData = new Uint8Array([0, 1]).buffer;
+    const result = await analyzeVoice(audioData);
+
+    const total = Object.values(result).reduce((s, v) => s + v, 0);
+    expect(total).toBeCloseTo(1, 5);
+  });
+
+  it('API が 4xx/5xx を返した場合はエラーをスローする', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(401) as unknown as Response);
+
+    const audioData = new Uint8Array([0]).buffer;
+    await expect(analyzeVoice(audioData)).rejects.toThrow();
+  });
+
+  it('リクエストヘッダーに API キーが含まれる（ボディには含まない）', async () => {
+    mockFetch.mockResolvedValueOnce(makeVoiceResponse([
+      { name: 'Joy', score: 1.0 },
+    ]) as unknown as Response);
+
+    const audioData = new Uint8Array([0]).buffer;
+    await analyzeVoice(audioData);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0];
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    // Authorization ヘッダーにキーが含まれることを確認
+    const authHeader = headers['Authorization'] ?? headers['authorization'] ?? '';
+    expect(authHeader).toBeTruthy();
+    // レスポンスボディには含まれないこと（API キーがボディに露出しないこと）
+    const bodyStr = typeof options?.body === 'string' ? options.body : '';
+    expect(bodyStr).not.toContain('test-api-key');
+    expect(bodyStr).not.toContain('test-secret-key');
+  });
+});
+
+describe('analyzeFace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.HUME_API_KEY = 'test-api-key';
+    process.env.HUME_SECRET_KEY = 'test-secret-key';
+  });
+
+  it('正常系：EmotionScore 形式のオブジェクトを返す', async () => {
+    mockFetch.mockResolvedValueOnce(makeFaceResponse([
+      { name: 'Joy', score: 0.9 },
+      { name: 'Calmness', score: 0.05 },
+      { name: 'Anger', score: 0.03 },
+      { name: 'Anxiety', score: 0.01 },
+      { name: 'Stress', score: 0.005 },
+      { name: 'Contempt', score: 0.005 },
+    ]) as unknown as Response);
+
+    const imageBase64 = 'data:image/jpeg;base64,/9j/fake==';
+    const result = await analyzeFace(imageBase64);
+
+    expect(result).toHaveProperty('ANGRY');
+    expect(result).toHaveProperty('ANXIOUS');
+    expect(result).toHaveProperty('HAPPY');
+    expect(result).toHaveProperty('NEUTRAL');
+    expect(result).toHaveProperty('STRESSED');
+    expect(result).toHaveProperty('HIDING');
+
+    Object.values(result).forEach((v) => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('API が 4xx/5xx を返した場合はエラーをスローする', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(403) as unknown as Response);
+
+    const imageBase64 = 'data:image/jpeg;base64,/9j/fake==';
+    await expect(analyzeFace(imageBase64)).rejects.toThrow();
+  });
+});

--- a/app/api/analyze-face/route.ts
+++ b/app/api/analyze-face/route.ts
@@ -1,0 +1,49 @@
+/**
+ * 表情解析 API Route
+ * POST /api/analyze-face
+ * クライアントから送信された画像データを Hume AI に転送し、
+ * EmotionScore 形式のレスポンスを返す
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { analyzeFace } from '../../../lib/hume';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // 環境変数チェック（機密値はメッセージに含めない）
+  if (!process.env.HUME_API_KEY || !process.env.HUME_SECRET_KEY) {
+    return NextResponse.json(
+      { error: 'API keys are not configured on the server.' },
+      { status: 400 }
+    );
+  }
+
+  // JSON ボディから画像 Base64 取得
+  let imageBase64: string;
+  try {
+    const body = await req.json() as Record<string, unknown>;
+    if (typeof body.image !== 'string' || !body.image) {
+      return NextResponse.json(
+        { error: 'image field is required.' },
+        { status: 422 }
+      );
+    }
+    imageBase64 = body.image;
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON body.' },
+      { status: 422 }
+    );
+  }
+
+  // Hume AI 呼び出し
+  try {
+    const score = await analyzeFace(imageBase64);
+    return NextResponse.json({ score }, { status: 200 });
+  } catch {
+    // Hume AI のエラー詳細をクライアントに漏らさない
+    return NextResponse.json(
+      { error: 'Failed to analyze face. Please try again later.' },
+      { status: 502 }
+    );
+  }
+}

--- a/app/api/analyze-voice/route.ts
+++ b/app/api/analyze-voice/route.ts
@@ -1,0 +1,50 @@
+/**
+ * 音声解析 API Route
+ * POST /api/analyze-voice
+ * クライアントから送信された音声データを Hume AI に転送し、
+ * EmotionScore 形式のレスポンスを返す
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { analyzeVoice } from '../../../lib/hume';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // 環境変数チェック（機密値はメッセージに含めない）
+  if (!process.env.HUME_API_KEY || !process.env.HUME_SECRET_KEY) {
+    return NextResponse.json(
+      { error: 'API keys are not configured on the server.' },
+      { status: 400 }
+    );
+  }
+
+  // FormData からの音声バイナリ取得
+  let audioBuffer: ArrayBuffer;
+  try {
+    const formData = await req.formData();
+    const audioFile = formData.get('audio');
+    if (!audioFile || !(audioFile instanceof Blob)) {
+      return NextResponse.json(
+        { error: 'audio field is required.' },
+        { status: 422 }
+      );
+    }
+    audioBuffer = await audioFile.arrayBuffer();
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid request body.' },
+      { status: 422 }
+    );
+  }
+
+  // Hume AI 呼び出し
+  try {
+    const score = await analyzeVoice(audioBuffer);
+    return NextResponse.json({ score }, { status: 200 });
+  } catch {
+    // Hume AI のエラー詳細をクライアントに漏らさない
+    return NextResponse.json(
+      { error: 'Failed to analyze voice. Please try again later.' },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/hume.ts
+++ b/lib/hume.ts
@@ -1,0 +1,174 @@
+/**
+ * Hume AI 接続ロジック
+ * HUME_API_KEY / HUME_SECRET_KEY はサーバー環境変数からのみ読み込む
+ * クライアントへ機密値を露出しない
+ */
+
+import { EmotionLabel, EmotionScore } from './types';
+
+/** Hume AI API のベース URL */
+const HUME_API_BASE = 'https://api.hume.ai/v0';
+
+/**
+ * Hume AI の感情名を EmotionLabel にマッピングするテーブル
+ * Hume が返す感情名 → 本アプリのラベルへの変換
+ */
+const HUME_EMOTION_MAP: Record<string, EmotionLabel> = {
+  // 怒り系
+  Anger: 'ANGRY',
+  Contempt: 'HIDING',
+  // 不安系
+  Anxiety: 'ANXIOUS',
+  Fear: 'ANXIOUS',
+  // 喜び系
+  Joy: 'HAPPY',
+  Amusement: 'HAPPY',
+  Excitement: 'HAPPY',
+  // 通常系
+  Calmness: 'NEUTRAL',
+  Contentment: 'NEUTRAL',
+  // ストレス系
+  Stress: 'STRESSED',
+  Distress: 'STRESSED',
+  // 隠蔽系
+  Awkwardness: 'HIDING',
+};
+
+/** ゼロ初期化した EmotionScore を返す */
+function zeroScore(): Record<EmotionLabel, number> {
+  return {
+    ANGRY: 0,
+    ANXIOUS: 0,
+    HAPPY: 0,
+    NEUTRAL: 0,
+    STRESSED: 0,
+    HIDING: 0,
+  };
+}
+
+/**
+ * Hume AI のレスポンスから感情スコアを集計して正規化する
+ * @param emotions - Hume が返す { name, score } の配列
+ * @returns 正規化済み EmotionScore
+ */
+function aggregateEmotions(emotions: Array<{ name: string; score: number }>): EmotionScore {
+  const raw = zeroScore();
+
+  for (const { name, score } of emotions) {
+    const label = HUME_EMOTION_MAP[name];
+    if (label) {
+      raw[label] += score;
+    }
+  }
+
+  // 全スコア合計で正規化
+  const total = Object.values(raw).reduce((s, v) => s + v, 0);
+  if (total === 0) {
+    raw.NEUTRAL = 1;
+    return raw as EmotionScore;
+  }
+
+  const normalized = zeroScore();
+  for (const key of Object.keys(raw) as EmotionLabel[]) {
+    normalized[key] = raw[key] / total;
+  }
+  return normalized as EmotionScore;
+}
+
+/**
+ * 音声データを Hume AI に送信して EmotionScore を返す
+ * @param audioBuffer - 音声の ArrayBuffer
+ * @throws API キーが未設定の場合、または Hume AI がエラーを返した場合
+ */
+export async function analyzeVoice(audioBuffer: ArrayBuffer): Promise<EmotionScore> {
+  const apiKey = process.env.HUME_API_KEY;
+  // キーが未設定の場合は早期エラー（機密値はメッセージに含めない）
+  if (!apiKey) {
+    throw new Error('HUME_API_KEY is not configured');
+  }
+
+  const formData = new FormData();
+  const audioBlob = new Blob([audioBuffer], { type: 'audio/webm' });
+  formData.append('file', audioBlob, 'audio.webm');
+  formData.append('models', JSON.stringify({ prosody: {} }));
+
+  const res = await fetch(`${HUME_API_BASE}/batch/jobs`, {
+    method: 'POST',
+    headers: {
+      // API キーはリクエストヘッダーにのみ含める
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    // エラーメッセージにステータスのみ含め、機密値は含めない
+    throw new Error(`Hume AI voice API error: ${res.status}`);
+  }
+
+  const json = await res.json();
+  const predictions: Array<{ name: string; score: number }> = [];
+
+  try {
+    const grouped =
+      json.results.predictions[0].models.prosody.grouped_predictions[0].predictions;
+    for (const pred of grouped) {
+      for (const e of pred.emotions) {
+        predictions.push({ name: e.name, score: e.score });
+      }
+    }
+  } catch {
+    // パースエラーは NEUTRAL に丸める
+    return { ANGRY: 0, ANXIOUS: 0, HAPPY: 0, NEUTRAL: 1, STRESSED: 0, HIDING: 0 };
+  }
+
+  return aggregateEmotions(predictions);
+}
+
+/**
+ * 顔画像（Base64）を Hume AI に送信して EmotionScore を返す
+ * @param imageBase64 - data URL 形式の Base64 画像
+ * @throws API キーが未設定の場合、または Hume AI がエラーを返した場合
+ */
+export async function analyzeFace(imageBase64: string): Promise<EmotionScore> {
+  const apiKey = process.env.HUME_API_KEY;
+  if (!apiKey) {
+    throw new Error('HUME_API_KEY is not configured');
+  }
+
+  const res = await fetch(`${HUME_API_BASE}/batch/jobs`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      models: { face: {} },
+      urls: [],
+      text: [],
+      // Base64 画像を inline で送信
+      files: [{ data: imageBase64 }],
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Hume AI face API error: ${res.status}`);
+  }
+
+  const json = await res.json();
+  const predictions: Array<{ name: string; score: number }> = [];
+
+  try {
+    const grouped =
+      json.results.predictions[0].models.face.grouped_predictions[0].predictions;
+    for (const pred of grouped) {
+      for (const e of pred.emotions) {
+        predictions.push({ name: e.name, score: e.score });
+      }
+    }
+  } catch {
+    return { ANGRY: 0, ANXIOUS: 0, HAPPY: 0, NEUTRAL: 1, STRESSED: 0, HIDING: 0 };
+  }
+
+  return aggregateEmotions(predictions);
+}


### PR DESCRIPTION
## 概要

Issue #3 の実装。音声・表情解析 API Routes をサーバーサイドで実装し、Hume AI と安全に接続する。

## 変更内容

- `lib/hume.ts` — Hume AI 接続ロジックの共通化（音声・表情）
- `app/api/analyze-voice/route.ts` — 音声解析 API Route
- `app/api/analyze-face/route.ts` — 表情解析 API Route

## テスト

- `__tests__/lib/hume.test.ts` — fetch モックによる Hume 接続ロジックのテスト
- `__tests__/api/analyzeVoice.test.ts` — 音声解析 API Route のテスト
- `__tests__/api/analyzeFace.test.ts` — 表情解析 API Route のテスト

Docker コンテナ内でテスト 9 スイート 52 件すべてグリーンを確認済み。

## セキュリティ

- HUME_API_KEY / HUME_SECRET_KEY はサーバー環境変数からのみ読み込み
- API キー未設定時 400、バリデーションエラー 422、Hume 障害時 502 を返す
- ログ・レスポンスに機密値を含まない設計

Closes #3