### PR TITLE
fix: yaml パッケージを devDependencies に追加して CI を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ts-node": "^10.9.2",
     "@testing-library/react": "^14.3.1",
     "@testing-library/jest-dom": "^6.4.6",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "yaml": "^2.4.5"
   }
 }


### PR DESCRIPTION
## 概要

PR #14 マージ後に CI の TypeScript 型チェックが失敗していた問題を修正します。

## 原因

`__tests__/docker/compose.prod.test.ts` で `yaml` パッケージを使用しているが、`package.json` の `devDependencies` への登録が漏れていた。

```
error TS2307: Cannot find module 'yaml' or its corresponding type declarations.
```

## 修正内容

- `package.json` の `devDependencies` に `yaml@^2.4.5` を追加

## 確認

- TypeScript 型チェック（`tsc --noEmit`）が通ること
- compose.prod.test.ts のテストが通ること