### PR TITLE
fix: docker-compose.prod.yml の environment をマップ形式に修正して CI テストを修正

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,9 +11,9 @@ services:
     ports:
       - '3000:3000'
     environment:
-      - NODE_ENV=production
-      - HUME_API_KEY=${HUME_API_KEY}
-      - HUME_SECRET_KEY=${HUME_SECRET_KEY}
+      NODE_ENV: production
+      HUME_API_KEY: ${HUME_API_KEY}
+      HUME_SECRET_KEY: ${HUME_SECRET_KEY}
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## 概要

`compose.prod.test.ts` の `NODE_ENV が production に設定されている` テストが失敗していた問題を修正します。

## 原因

`docker-compose.prod.yml` の `environment` がリスト形式（`- KEY=value`）だったため、YAML パース後は配列になる。テストは `env.NODE_ENV` でオブジェクト参照しているため `undefined` になりテスト失敗。

```
Expected: "production"
Received: undefined
```

## 修正内容

`environment` をリスト形式からマップ形式（`KEY: value`）に変更：

```yaml
# 修正前
environment:
  - NODE_ENV=production

# 修正後
environment:
  NODE_ENV: production
```

## 確認

- compose.prod.test.ts のすべてのテストが通ること
- `docker compose -f docker-compose.prod.yml` でも環境変数が正常に設定されること