### PR TITLE
issue #17: ログインユーザー識別のための認証基盤を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ HUME_API_KEY=your_hume_api_key_here
 # HUME_API_KEY と同時に発行される
 HUME_SECRET_KEY=your_hume_secret_key_here
 
+# Auth.js のセッション署名に使う秘密鍵
+AUTH_SECRET=replace_with_a_long_random_secret
+
+# MVP 用のログイン資格情報
+AUTH_DEMO_EMAIL=demo@example.com
+AUTH_DEMO_PASSWORD=change_me_securely
+
 # Node.js 実行環境
 # 値: development または production
 NODE_ENV=development

--- a/__tests__/api/authMe.test.ts
+++ b/__tests__/api/authMe.test.ts
@@ -1,0 +1,49 @@
+/**
+ * app/api/auth/me/route.ts のテスト
+ * ログイン中ユーザーの取得 API を検証する
+ */
+
+jest.mock('../../lib/currentUser', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import { getCurrentUser as mockGetCurrentUser } from '../../lib/currentUser';
+import { GET } from '../../app/api/auth/me/route';
+
+const mockedGetCurrentUser = mockGetCurrentUser as jest.MockedFunction<typeof mockGetCurrentUser>;
+
+describe('GET /api/auth/me', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未ログイン時は 401 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce(null);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('ログイン中は user を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-123',
+      name: 'Emotion Lens User',
+      email: 'user@example.com',
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      user: {
+        id: 'user-123',
+        name: 'Emotion Lens User',
+        email: 'user@example.com',
+      },
+    });
+  });
+});

--- a/__tests__/app/login/page.test.tsx
+++ b/__tests__/app/login/page.test.tsx
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+/**
+ * app/login/page.tsx のテスト
+ * ログイン導線の最小 UI を検証する
+ */
+
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next-auth/react', () => ({
+  signIn: jest.fn(),
+}));
+
+import LoginPage from '../../../app/login/page';
+
+describe('LoginPage', () => {
+  it('ログイン見出しが表示される', () => {
+    render(<LoginPage />);
+    expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+  });
+
+  it('メールアドレスとパスワードの入力欄が表示される', () => {
+    render(<LoginPage />);
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+  });
+
+  it('送信ボタンが表示される', () => {
+    render(<LoginPage />);
+    expect(screen.getByRole('button', { name: 'ログインする' })).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/currentUser.test.ts
+++ b/__tests__/lib/currentUser.test.ts
@@ -1,0 +1,48 @@
+/**
+ * lib/currentUser.ts のテスト
+ * サーバー側でログインユーザーを安全に解決できることを検証する
+ */
+
+jest.mock('../../auth', () => ({
+  auth: jest.fn(),
+}));
+
+import { auth as mockAuth } from '../../auth';
+import { getCurrentUser, requireCurrentUser } from '../../lib/currentUser';
+
+const mockedAuth = mockAuth as jest.MockedFunction<typeof mockAuth>;
+
+describe('currentUser helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('セッションがない場合 getCurrentUser は null を返す', async () => {
+    mockedAuth.mockResolvedValueOnce(null);
+
+    await expect(getCurrentUser()).resolves.toBeNull();
+  });
+
+  it('user.id を含むセッションがある場合 getCurrentUser はユーザー情報を返す', async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: {
+        id: 'user-123',
+        name: 'Emotion Lens User',
+        email: 'user@example.com',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    });
+
+    await expect(getCurrentUser()).resolves.toEqual({
+      id: 'user-123',
+      name: 'Emotion Lens User',
+      email: 'user@example.com',
+    });
+  });
+
+  it('requireCurrentUser は未ログイン時に Unauthorized エラーを投げる', async () => {
+    mockedAuth.mockResolvedValueOnce(null);
+
+    await expect(requireCurrentUser()).rejects.toThrow('Unauthorized');
+  });
+});

--- a/__tests__/lib/currentUser.test.ts
+++ b/__tests__/lib/currentUser.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../auth', () => ({
 import { auth as mockAuth } from '../../auth';
 import { getCurrentUser, requireCurrentUser } from '../../lib/currentUser';
 
-const mockedAuth = mockAuth as jest.MockedFunction<typeof mockAuth>;
+const mockedAuth = mockAuth as unknown as jest.Mock<Promise<unknown>, []>;
 
 describe('currentUser helpers', () => {
   beforeEach(() => {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '../../../../auth';
+
+export const { GET, POST } = handlers;

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '../../../../lib/currentUser';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return NextResponse.json({ user }, { status: 200 });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { AuthNav } from '../components/layout/AuthNav';
 
 export const metadata: Metadata = {
   title: 'EmotionLens',
@@ -13,7 +14,12 @@ type RootLayoutProps = {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="ja" data-theme="emotion-dark">
-      <body className="min-h-screen bg-base-100 text-base-content">{children}</body>
+      <body className="min-h-screen bg-base-100 text-base-content">
+        <div className="flex justify-end border-b border-el-border bg-base-200 px-4 py-2">
+          <AuthNav />
+        </div>
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { signIn } from 'next-auth/react';
+
+export default function LoginPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function authenticate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const result = await signIn('credentials', {
+      email: String(formData.get('email') ?? ''),
+      password: String(formData.get('password') ?? ''),
+      redirect: false,
+      callbackUrl: '/',
+    });
+
+    if (!result || result.error) {
+      setError('ログインに失敗しました');
+      setIsSubmitting(false);
+      return;
+    }
+
+    window.location.href = result.url ?? '/';
+  }
+
+  return (
+    <div data-theme="emotion-dark" className="flex min-h-screen items-center justify-center bg-base-100 px-4">
+      <div className="card w-full max-w-md bg-base-200 shadow-xl">
+        <div className="card-body gap-4">
+          <div className="space-y-2 text-center">
+            <h1 className="text-2xl font-bold">ログイン</h1>
+            <p className="text-sm text-el-muted">
+              EmotionLens のセッションデータ保存にはログインが必要です
+            </p>
+          </div>
+          <form onSubmit={authenticate} className="space-y-4">
+            <label className="form-control w-full gap-2">
+              <span className="label-text">メールアドレス</span>
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                className="input input-bordered w-full"
+                required
+              />
+            </label>
+            <label className="form-control w-full gap-2">
+              <span className="label-text">パスワード</span>
+              <input
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                className="input input-bordered w-full"
+                required
+              />
+            </label>
+            {error && <p className="text-sm text-error">{error}</p>}
+            <button type="submit" className="btn btn-primary w-full" disabled={isSubmitting}>
+              ログインする
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,58 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+
+const demoEmail = process.env.AUTH_DEMO_EMAIL;
+const demoPassword = process.env.AUTH_DEMO_PASSWORD;
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  session: {
+    strategy: 'jwt',
+  },
+  pages: {
+    signIn: '/login',
+  },
+  providers: [
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      authorize(credentials) {
+        if (typeof credentials?.email !== 'string' || typeof credentials?.password !== 'string') {
+          return null;
+        }
+
+        if (!demoEmail || !demoPassword) {
+          return null;
+        }
+
+        if (credentials.email !== demoEmail || credentials.password !== demoPassword) {
+          return null;
+        }
+
+        return {
+          id: 'demo-user',
+          name: 'Demo User',
+          email: demoEmail,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.sub = user.id;
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.sub ?? '';
+      }
+
+      return session;
+    },
+  },
+});

--- a/components/layout/AuthNav.tsx
+++ b/components/layout/AuthNav.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { auth, signOut } from '../../auth';
+
+export async function AuthNav() {
+  const session = await auth();
+  const user = session?.user;
+
+  if (!user) {
+    return (
+      <Link href="/login" className="btn btn-ghost btn-sm">
+        ログイン
+      </Link>
+    );
+  }
+
+  async function handleSignOut() {
+    'use server';
+
+    await signOut({ redirectTo: '/login' });
+  }
+
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <span className="text-el-muted">{user.email ?? user.name ?? 'ログイン中'}</span>
+      <form action={handleSignOut}>
+        <button type="submit" className="btn btn-ghost btn-sm">
+          ログアウト
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
 
+jest.mock('server-only', () => ({}), { virtual: true });
+
 // Recharts が必要とする ResizeObserver をモック
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),

--- a/lib/currentUser.ts
+++ b/lib/currentUser.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import { auth } from '../auth';
+
+export type CurrentUser = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+export async function getCurrentUser(): Promise<CurrentUser | null> {
+  const session = await auth();
+  const user = session?.user;
+
+  if (!user || typeof user.id !== 'string' || user.id.length === 0) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    name: user.name ?? null,
+    email: user.email ?? null,
+  };
+}
+
+export async function requireCurrentUser(): Promise<CurrentUser> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    throw new Error('Unauthorized');
+  }
+
+  return user;
+}

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,13 @@
+import type { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: DefaultSession['user'] & {
+      id: string;
+    };
+  }
+
+  interface User {
+    id: string;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "daisyui": "^4.12.10",
         "framer-motion": "^11.2.12",
         "next": "14.2.5",
+        "next-auth": "^5.0.0-beta.25",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^2.12.7"
@@ -33,7 +34,8 @@
         "tailwindcss": "^3.4.13",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.2",
+        "yaml": "^2.4.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -54,6 +56,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1641,6 +1672,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6570,6 +6610,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7075,6 +7124,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7146,6 +7222,15 @@
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7599,6 +7684,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
@@ -9428,6 +9532,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "next": "14.2.5",
+    "next-auth": "^5.0.0-beta.25",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "framer-motion": "^11.2.12",


### PR DESCRIPTION
## 概要
- issue #17 の対応として、認証基盤の土台を追加
- App Router でログイン / ログアウト / セッション識別の最小導線を追加
- 保護 API で利用するサーバー側の current user 解決を追加

## 変更内容
- Auth.js（Credentials）による最小構成の認証設定を追加
- `/api/auth/[...nextauth]` と `/api/auth/me` を追加
- `getCurrentUser` / `requireCurrentUser` ヘルパーを追加
- ログイン画面とヘッダーのログイン導線を追加
- 認証基盤向けテストを追加

## 関連 Issue
Closes #17

## 確認
- GitHub Actions（CI - テストと品質チェック）: success
- Docker での型チェックと認証テスト: success
