### PR TITLE
issue #18: PostgreSQL のユーザー単位セッションスキーマを設計

### DIFF
--- a/__tests__/db/sessionSchemaMigration.test.ts
+++ b/__tests__/db/sessionSchemaMigration.test.ts
@@ -1,0 +1,57 @@
+/**
+ * issue #18: PostgreSQL スキーマ設計テスト
+ * ユーザー単位セッション保存の migration 定義を検証する
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const migrationPath = path.join(
+  __dirname,
+  '../../db/migrations/001_issue18_user_session_schema.sql',
+);
+
+describe('issue #18 migration schema', () => {
+  it('migration ファイルが存在する', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('users / emotion_sessions / session_alerts テーブルを定義する', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS users/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS emotion_sessions/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS session_alerts/i);
+  });
+
+  it('emotion_sessions が user_id 外部キーを持つ', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    expect(sql).toMatch(/user_id\s+TEXT\s+NOT NULL/i);
+    expect(sql).toMatch(/FOREIGN KEY\s*\(user_id\)\s*REFERENCES\s*users\s*\(id\)/i);
+  });
+
+  it('session_alerts が session_id 外部キーを持つ', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    expect(sql).toMatch(/session_id\s+TEXT\s+NOT NULL/i);
+    expect(sql).toMatch(
+      /FOREIGN KEY\s*\(session_id\)\s*REFERENCES\s*emotion_sessions\s*\(session_id\)/i,
+    );
+  });
+
+  it('最新取得・一覧取得・詳細取得を想定したインデックスを含む', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_sessions_user_started_at/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_alerts_session_timestamp/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_alerts_label_timestamp/i);
+  });
+
+  it('保持方針と migration 方針がコメントとして明記される', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    expect(sql).toMatch(/retention policy/i);
+    expect(sql).toMatch(/migration strategy/i);
+  });
+});

--- a/db/migrations/001_issue18_user_session_schema.sql
+++ b/db/migrations/001_issue18_user_session_schema.sql
@@ -1,0 +1,64 @@
+-- issue #18
+-- migration strategy:
+-- 1) create new tables with IF NOT EXISTS to keep migration idempotent
+-- 2) add indexes separately for query patterns (latest/list/detail)
+-- 3) keep payload flexible with JSONB while persisting key metadata columns
+--
+-- retention policy:
+-- - keep emotion_sessions for 180 days by default
+-- - keep session_alerts for 365 days by default
+-- - execute cleanup by scheduled job (not in this migration)
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  display_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS emotion_sessions (
+  session_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  frame_count INTEGER NOT NULL DEFAULT 0 CHECK (frame_count >= 0),
+  alert_count INTEGER NOT NULL DEFAULT 0 CHECK (alert_count >= 0),
+  summary_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT fk_emotion_sessions_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS session_alerts (
+  id BIGSERIAL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  score NUMERIC(5, 4) NOT NULL CHECK (score >= 0 AND score <= 1),
+  detected_at TIMESTAMPTZ NOT NULL,
+  metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT fk_session_alerts_session
+    FOREIGN KEY (session_id) REFERENCES emotion_sessions (session_id) ON DELETE CASCADE,
+  CONSTRAINT fk_session_alerts_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+-- latest session query: SELECT ... WHERE user_id = ? ORDER BY started_at DESC LIMIT 1
+CREATE INDEX IF NOT EXISTS idx_sessions_user_started_at
+  ON emotion_sessions (user_id, started_at DESC);
+
+-- session list query: SELECT ... WHERE user_id = ? ORDER BY created_at DESC
+CREATE INDEX IF NOT EXISTS idx_sessions_user_created_at
+  ON emotion_sessions (user_id, created_at DESC);
+
+-- session detail query: SELECT ... WHERE session_id = ? ORDER BY detected_at DESC
+CREATE INDEX IF NOT EXISTS idx_alerts_session_timestamp
+  ON session_alerts (session_id, detected_at DESC);
+
+-- alert list query: SELECT ... WHERE user_id = ? AND label = ? ORDER BY detected_at DESC
+CREATE INDEX IF NOT EXISTS idx_alerts_label_timestamp
+  ON session_alerts (user_id, label, detected_at DESC);


### PR DESCRIPTION
## 概要
- issue #18 に対応する PostgreSQL スキーマ設計を追加
- user_id 軸で sessions / alerts を安全に保持する構成を導入
- インデックス方針と保持方針、最小 migration 方針を明文化

## 実装方針
- users / emotion_sessions / session_alerts を定義
- 最新取得・一覧取得・詳細取得を想定したインデックスを作成
- 保存粒度は「集計済みメタデータ中心 + 必要最小限の JSON」を採用

## 関連 Issue
Closes #18

## 進め方
- 先にテストを追加
- テストを満たすスキーマ定義と migration を実装
- Docker でテストを検証
