### PR TITLE
issue #19: ログインユーザー専用のセッション保存/取得 API を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ AUTH_SECRET=replace_with_a_long_random_secret
 AUTH_DEMO_EMAIL=demo@example.com
 AUTH_DEMO_PASSWORD=change_me_securely
 
+# PostgreSQL 接続文字列
+# 例: postgres://postgres:postgres@localhost:5432/emotion_lens
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/emotion_lens
+
 # Node.js 実行環境
 # 値: development または production
 NODE_ENV=development

--- a/__tests__/api/sessionDetail.test.ts
+++ b/__tests__/api/sessionDetail.test.ts
@@ -1,0 +1,80 @@
+/**
+ * app/api/sessions/[sessionId]/route.ts のテスト
+ * 詳細取得 API の認証と所有者チェックを検証する
+ */
+
+jest.mock('../../lib/currentUser', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock('../../lib/sessionRepository', () => ({
+  getSessionByIdForUser: jest.fn(),
+}));
+
+import { getCurrentUser as mockGetCurrentUser } from '../../lib/currentUser';
+import { getSessionByIdForUser as mockGetSessionByIdForUser } from '../../lib/sessionRepository';
+import { GET } from '../../app/api/sessions/[sessionId]/route';
+
+const mockedGetCurrentUser = mockGetCurrentUser as unknown as jest.Mock<Promise<unknown>, []>;
+const mockedGetSessionByIdForUser = mockGetSessionByIdForUser as unknown as jest.Mock<Promise<unknown>, [string, string]>;
+
+describe('GET /api/sessions/[sessionId]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未ログイン時は 401 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce(null);
+
+    const response = await GET(new Request('http://localhost/api/sessions/s-1'), {
+      params: { sessionId: 's-1' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('他人の session_id または存在しない場合は 404 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+    mockedGetSessionByIdForUser.mockResolvedValueOnce(null);
+
+    const response = await GET(new Request('http://localhost/api/sessions/s-2'), {
+      params: { sessionId: 's-2' },
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockedGetSessionByIdForUser).toHaveBeenCalledWith('user-1', 's-2');
+  });
+
+  it('ログインユーザーのセッションのみ 200 で返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+    mockedGetSessionByIdForUser.mockResolvedValueOnce({
+      sessionId: 's-1',
+      startedAt: 1000,
+      frames: [],
+      allAlerts: [],
+    });
+
+    const response = await GET(new Request('http://localhost/api/sessions/s-1'), {
+      params: { sessionId: 's-1' },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      session: {
+        sessionId: 's-1',
+        startedAt: 1000,
+        frames: [],
+        allAlerts: [],
+      },
+    });
+  });
+});

--- a/__tests__/api/sessionsLatest.test.ts
+++ b/__tests__/api/sessionsLatest.test.ts
@@ -1,0 +1,61 @@
+/**
+ * app/api/sessions/latest/route.ts のテスト
+ * 最新取得 API の認証と user スコープを検証する
+ */
+
+jest.mock('../../lib/currentUser', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock('../../lib/sessionRepository', () => ({
+  getLatestSessionForUser: jest.fn(),
+}));
+
+import { getCurrentUser as mockGetCurrentUser } from '../../lib/currentUser';
+import { getLatestSessionForUser as mockGetLatestSessionForUser } from '../../lib/sessionRepository';
+import { GET } from '../../app/api/sessions/latest/route';
+
+const mockedGetCurrentUser = mockGetCurrentUser as unknown as jest.Mock<Promise<unknown>, []>;
+const mockedGetLatestSessionForUser = mockGetLatestSessionForUser as unknown as jest.Mock<Promise<unknown>, [string]>;
+
+describe('GET /api/sessions/latest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未ログイン時は 401 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+  });
+
+  it('ログイン中は user_id で最新セッションを取得する', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+    mockedGetLatestSessionForUser.mockResolvedValueOnce({
+      sessionId: 's-1',
+      startedAt: 1000,
+      frames: [],
+      allAlerts: [],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockedGetLatestSessionForUser).toHaveBeenCalledWith('user-1');
+    expect(body).toEqual({
+      session: {
+        sessionId: 's-1',
+        startedAt: 1000,
+        frames: [],
+        allAlerts: [],
+      },
+    });
+  });
+});

--- a/__tests__/api/sessionsPost.test.ts
+++ b/__tests__/api/sessionsPost.test.ts
@@ -1,0 +1,77 @@
+/**
+ * app/api/sessions/route.ts のテスト
+ * 保存 API の認証・バリデーション・保存呼び出しを検証する
+ */
+
+import { NextRequest } from 'next/server';
+
+jest.mock('../../lib/currentUser', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock('../../lib/sessionRepository', () => ({
+  saveSessionForUser: jest.fn(),
+}));
+
+import { getCurrentUser as mockGetCurrentUser } from '../../lib/currentUser';
+import { saveSessionForUser as mockSaveSessionForUser } from '../../lib/sessionRepository';
+import { POST } from '../../app/api/sessions/route';
+
+const mockedGetCurrentUser = mockGetCurrentUser as unknown as jest.Mock<Promise<unknown>, []>;
+const mockedSaveSessionForUser = mockSaveSessionForUser as unknown as jest.Mock<Promise<void>, [string, unknown, unknown]>;
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/sessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未ログイン時は 401 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce(null);
+
+    const response = await POST(makeRequest({ session: {} }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('バリデーション不正時は 422 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+
+    const response = await POST(makeRequest({ session: { sessionId: 's-1' } }));
+
+    expect(response.status).toBe(422);
+  });
+
+  it('ログイン中かつ有効 payload の場合は保存して 200 を返す', async () => {
+    mockedGetCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    });
+
+    const session = {
+      sessionId: 's-1',
+      startedAt: Date.now(),
+      frames: [],
+      allAlerts: [],
+    };
+
+    const response = await POST(makeRequest({ session }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockedSaveSessionForUser).toHaveBeenCalledWith('user-1', expect.objectContaining({ email: 'user@example.com' }), session);
+    expect(body).toEqual({ sessionId: 's-1' });
+  });
+});

--- a/app/api/sessions/[sessionId]/route.ts
+++ b/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '../../../../lib/currentUser';
+import { getSessionByIdForUser } from '../../../../lib/sessionRepository';
+
+type RouteContext = {
+  params: {
+    sessionId: string;
+  };
+};
+
+export async function GET(_req: Request, { params }: RouteContext): Promise<NextResponse> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return NextResponse.json({ error: 'sessionId is required.' }, { status: 422 });
+  }
+
+  try {
+    const session = await getSessionByIdForUser(user.id, sessionId);
+    if (!session) {
+      return NextResponse.json({ error: 'Not found.' }, { status: 404 });
+    }
+
+    return NextResponse.json({ session }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch session.' }, { status: 500 });
+  }
+}

--- a/app/api/sessions/latest/route.ts
+++ b/app/api/sessions/latest/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '../../../../lib/currentUser';
+import { getLatestSessionForUser } from '../../../../lib/sessionRepository';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const session = await getLatestSessionForUser(user.id);
+    return NextResponse.json({ session }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch latest session.' }, { status: 500 });
+  }
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '../../../lib/currentUser';
+import { saveSessionForUser } from '../../../lib/sessionRepository';
+import type { SessionData } from '../../../lib/types';
+
+type SessionBody = {
+  session?: unknown;
+};
+
+function isSessionData(value: unknown): value is SessionData {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<SessionData>;
+  return (
+    typeof candidate.sessionId === 'string' &&
+    typeof candidate.startedAt === 'number' &&
+    Array.isArray(candidate.frames) &&
+    Array.isArray(candidate.allAlerts)
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let session: SessionData;
+  try {
+    const body = (await req.json()) as SessionBody;
+    if (!isSessionData(body.session)) {
+      return NextResponse.json({ error: 'Invalid session payload.' }, { status: 422 });
+    }
+    session = body.session;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 422 });
+  }
+
+  try {
+    await saveSessionForUser(user.id, user, session);
+    return NextResponse.json({ sessionId: session.sessionId }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to save session.' }, { status: 500 });
+  }
+}

--- a/lib/postgres.ts
+++ b/lib/postgres.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+
+import { Pool } from 'pg';
+
+declare global {
+  var __emotionLensPgPool: Pool | undefined;
+}
+
+function createPool(): Pool {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not configured on the server.');
+  }
+
+  return new Pool({ connectionString });
+}
+
+export const postgresPool = globalThis.__emotionLensPgPool ?? createPool();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__emotionLensPgPool = postgresPool;
+}

--- a/lib/sessionRepository.ts
+++ b/lib/sessionRepository.ts
@@ -1,0 +1,144 @@
+import 'server-only';
+
+import type { CurrentUser } from './currentUser';
+import { postgresPool } from './postgres';
+import type { SessionData } from './types';
+
+type SessionRow = {
+  payload_json: SessionData;
+};
+
+function ensureUserEmail(user: CurrentUser): string {
+  return user.email ?? `${user.id}@emotionlens.local`;
+}
+
+export async function saveSessionForUser(
+  userId: string,
+  user: CurrentUser,
+  session: SessionData,
+): Promise<void> {
+  const client = await postgresPool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    await client.query(
+      `
+        INSERT INTO users (id, email, display_name)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (id)
+        DO UPDATE SET
+          email = EXCLUDED.email,
+          display_name = EXCLUDED.display_name,
+          updated_at = NOW()
+      `,
+      [userId, ensureUserEmail(user), user.name],
+    );
+
+    await client.query(
+      `
+        INSERT INTO emotion_sessions (
+          session_id,
+          user_id,
+          started_at,
+          frame_count,
+          alert_count,
+          summary_json,
+          payload_json,
+          updated_at
+        )
+        VALUES (
+          $1,
+          $2,
+          TO_TIMESTAMP($3 / 1000.0),
+          $4,
+          $5,
+          $6::jsonb,
+          $7::jsonb,
+          NOW()
+        )
+        ON CONFLICT (session_id)
+        DO UPDATE SET
+          user_id = EXCLUDED.user_id,
+          started_at = EXCLUDED.started_at,
+          frame_count = EXCLUDED.frame_count,
+          alert_count = EXCLUDED.alert_count,
+          summary_json = EXCLUDED.summary_json,
+          payload_json = EXCLUDED.payload_json,
+          updated_at = NOW()
+      `,
+      [
+        session.sessionId,
+        userId,
+        session.startedAt,
+        session.frames.length,
+        session.allAlerts.length,
+        JSON.stringify({
+          frameCount: session.frames.length,
+          alertCount: session.allAlerts.length,
+        }),
+        JSON.stringify(session),
+      ],
+    );
+
+    await client.query('DELETE FROM session_alerts WHERE session_id = $1', [session.sessionId]);
+
+    if (session.allAlerts.length > 0) {
+      for (const alert of session.allAlerts) {
+        await client.query(
+          `
+            INSERT INTO session_alerts (
+              session_id,
+              user_id,
+              label,
+              score,
+              detected_at,
+              metadata_json
+            )
+            VALUES ($1, $2, $3, $4, TO_TIMESTAMP($5 / 1000.0), '{}'::jsonb)
+          `,
+          [session.sessionId, userId, alert.label, alert.score, alert.timestamp],
+        );
+      }
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function getLatestSessionForUser(userId: string): Promise<SessionData | null> {
+  const result = await postgresPool.query<SessionRow>(
+    `
+      SELECT payload_json
+      FROM emotion_sessions
+      WHERE user_id = $1
+      ORDER BY started_at DESC
+      LIMIT 1
+    `,
+    [userId],
+  );
+
+  return result.rows[0]?.payload_json ?? null;
+}
+
+export async function getSessionByIdForUser(
+  userId: string,
+  sessionId: string,
+): Promise<SessionData | null> {
+  const result = await postgresPool.query<SessionRow>(
+    `
+      SELECT payload_json
+      FROM emotion_sessions
+      WHERE user_id = $1 AND session_id = $2
+      LIMIT 1
+    `,
+    [userId, sessionId],
+  );
+
+  return result.rows[0]?.payload_json ?? null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^11.2.12",
         "next": "14.2.5",
         "next-auth": "^5.0.0-beta.25",
+        "pg": "^8.13.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^2.12.7"
@@ -23,6 +24,7 @@
         "@testing-library/react": "^14.3.1",
         "@types/jest": "^29.5.13",
         "@types/node": "^20.16.5",
+        "@types/pg": "^8.11.10",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "autoprefixer": "^10.4.20",
@@ -2098,6 +2100,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -7462,6 +7476,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7684,6 +7787,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/preact": {
       "version": "10.24.3",
@@ -8381,6 +8523,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -9515,6 +9666,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "next": "14.2.5",
     "next-auth": "^5.0.0-beta.25",
+    "pg": "^8.13.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "framer-motion": "^11.2.12",
@@ -40,6 +41,7 @@
     "@testing-library/react": "^14.3.1",
     "@testing-library/jest-dom": "^6.4.6",
     "jest-environment-jsdom": "^29.7.0",
+    "@types/pg": "^8.11.10",
     "yaml": "^2.4.5"
   }
 }


### PR DESCRIPTION
## 概要
- issue #19 に対応し、ログインユーザー専用のセッション保存/取得 API を追加
- 保存時の user_id はサーバー側で強制付与
- 未ログイン拒否、所有者チェック、入力バリデーションを実装

## 実装方針
- `POST /api/sessions` でセッション保存
- `GET /api/sessions/latest` でログインユーザーの最新セッション取得
- `GET /api/sessions/[sessionId]` でログインユーザーの対象セッション詳細取得
- テストを先に追加し、要件を固定してから実装

## 関連 Issue
Closes #19
