### PR TITLE
issue #20: フロントエンドをログインユーザー限定の保存フローに接続

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -1,10 +1,46 @@
 /** @jest-environment jsdom */
 /**
  * app/page.tsx のテスト
- * メイン画面が正しく構成要素を持つことを確認する
+ * メイン画面の認証状態と保存フローを確認する
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import HomePage from '../../app/page';
+import type { SessionData } from '../../lib/types';
+
+const mockStartVideo = jest.fn();
+const mockStopVideo = jest.fn();
+const mockStartAudio = jest.fn();
+const mockStopAudio = jest.fn();
+const mockAnalyzeVoice = jest.fn();
+const mockAnalyzeFace = jest.fn();
+const mockAddScore = jest.fn();
+const mockClearAlerts = jest.fn();
+const mockStartSession = jest.fn();
+const mockEndSession = jest.fn<SessionData | null, []>();
+const mockAddFrame = jest.fn();
+
+const sampleSession: SessionData = {
+  sessionId: 'session-1',
+  startedAt: 1710000000000,
+  frames: [],
+  allAlerts: [],
+};
+
+const mockSessionStore = {
+  session: null as SessionData | null,
+  isActive: false,
+  startSession: mockStartSession,
+  endSession: mockEndSession,
+  addFrame: mockAddFrame,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
 
 // コンポーネント内で使う Hooks をモック
 jest.mock('../../hooks/useVideoCapture', () => ({
@@ -12,8 +48,8 @@ jest.mock('../../hooks/useVideoCapture', () => ({
     isCapturing: false,
     error: null,
     videoRef: { current: null },
-    start: jest.fn(),
-    stop: jest.fn(),
+    start: mockStartVideo,
+    stop: mockStopVideo,
   }),
 }));
 
@@ -21,8 +57,8 @@ jest.mock('../../hooks/useAudioCapture', () => ({
   useAudioCapture: () => ({
     isCapturing: false,
     error: null,
-    start: jest.fn(),
-    stop: jest.fn(),
+    start: mockStartAudio,
+    stop: mockStopAudio,
   }),
 }));
 
@@ -33,8 +69,8 @@ jest.mock('../../hooks/useEmotionAnalysis', () => ({
     mergedScore: null,
     isAnalyzing: false,
     error: null,
-    analyzeVoice: jest.fn(),
-    analyzeFace: jest.fn(),
+    analyzeVoice: mockAnalyzeVoice,
+    analyzeFace: mockAnalyzeFace,
   }),
 }));
 
@@ -42,33 +78,91 @@ jest.mock('../../hooks/useEmotionAlerts', () => ({
   useEmotionAlerts: () => ({
     alerts: [],
     latestAlert: null,
-    addScore: jest.fn(),
-    clearAlerts: jest.fn(),
+    addScore: mockAddScore,
+    clearAlerts: mockClearAlerts,
   }),
 }));
 
 jest.mock('../../hooks/useSessionStore', () => ({
-  useSessionStore: () => ({
-    session: null,
-    isActive: false,
-    startSession: jest.fn(),
-    endSession: jest.fn(),
-    addFrame: jest.fn(),
-  }),
+  useSessionStore: () => mockSessionStore,
 }));
 
 describe('HomePage', () => {
+  const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    mockSessionStore.session = null;
+    mockSessionStore.isActive = false;
+    mockEndSession.mockReset();
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
   it('ページが描画される（クラッシュしない）', () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
     expect(() => render(<HomePage />)).not.toThrow();
   });
 
   it('Header が含まれる（アプリ名が表示される）', () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
     render(<HomePage />);
     expect(screen.getByText('EmotionLens')).toBeInTheDocument();
   });
 
   it('開始ボタンが表示される', () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
     render(<HomePage />);
     expect(screen.getByRole('button', { name: /開始/ })).toBeInTheDocument();
+  });
+
+  it('未ログイン時は保存不可メッセージを表示する', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { error: 'Unauthorized' }));
+
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ログインするとセッションを保存できます')).toBeInTheDocument();
+    });
+  });
+
+  it('ログイン中に停止すると保存 API を呼ぶ', async () => {
+    mockSessionStore.isActive = true;
+    mockEndSession.mockReturnValue(sampleSession);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { user: { id: 'user-1', email: 'demo@example.com' } }))
+      .mockResolvedValueOnce(jsonResponse(200, { sessionId: sampleSession.sessionId }));
+
+    render(<HomePage />);
+
+    const stopButton = await screen.findByRole('button', { name: '停止' });
+    fireEvent.click(stopButton);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/sessions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session: sampleSession }),
+        }),
+      );
+    });
+  });
+
+  it('保存失敗時はエラーメッセージを表示する', async () => {
+    mockSessionStore.isActive = true;
+    mockEndSession.mockReturnValue(sampleSession);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { user: { id: 'user-1', email: 'demo@example.com' } }))
+      .mockResolvedValueOnce(jsonResponse(500, { error: 'Failed to save session.' }));
+
+    render(<HomePage />);
+
+    const stopButton = await screen.findByRole('button', { name: '停止' });
+    fireEvent.click(stopButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('セッションの保存に失敗しました')).toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/app/report/page.test.tsx
+++ b/__tests__/app/report/page.test.tsx
@@ -1,35 +1,85 @@
 /** @jest-environment jsdom */
 /**
  * app/report/page.tsx のテスト
- * レポート画面が正しく構成要素を持つことを確認する
+ * レポート画面の API 連携と状態表示を確認する
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import ReportPage from '../../../app/report/page';
+import type { SessionData } from '../../../lib/types';
+
+const mockSessionStore = {
+  session: null as SessionData | null,
+  isActive: false,
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+  addFrame: jest.fn(),
+};
+
+const sampleSession: SessionData = {
+  sessionId: 'session-1',
+  startedAt: 1710000000000,
+  frames: [],
+  allAlerts: [],
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
 
 // コンポーネント内で使う Hooks をモック
 jest.mock('../../../hooks/useSessionStore', () => ({
-  useSessionStore: () => ({
-    session: null,
-    isActive: false,
-    startSession: jest.fn(),
-    endSession: jest.fn(),
-    addFrame: jest.fn(),
-  }),
+  useSessionStore: () => mockSessionStore,
 }));
 
 describe('ReportPage', () => {
+  const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    mockSessionStore.session = null;
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
   it('ページが描画される（クラッシュしない）', () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
     expect(() => render(<ReportPage />)).not.toThrow();
   });
 
-  it('セッションデータがないとき「レポートデータなし」メッセージが表示される', () => {
+  it('読み込み中の状態を表示する', () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
+
     render(<ReportPage />);
-    expect(screen.getByText('レポートデータなし')).toBeInTheDocument();
+
+    expect(screen.getByText('レポートを読み込み中です')).toBeInTheDocument();
   });
 
-  it('セッションデータがないときページタイトルが表示される', () => {
+  it('未ログイン時はログイン導線メッセージを表示する', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { error: 'Unauthorized' }));
+
     render(<ReportPage />);
-    // セッションデータなし時は h2 が表示される
-    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('ログインするとレポートを表示できます')).toBeInTheDocument();
+    });
+  });
+
+  it('ログインユーザーの最新セッションを取得して表示する', async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+    fetchMock.mockResolvedValue(jsonResponse(200, { session: sampleSession }));
+
+    render(<ReportPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/sessions/latest', { cache: 'no-store' });
+    });
+
+    expect(await screen.findByText('セッションレポート')).toBeInTheDocument();
+    expect(getItemSpy).not.toHaveBeenCalled();
+
+    getItemSpy.mockRestore();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@
  * セッション開始・映像プレビュー・感情パネル・アラート通知を統合する
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Header } from '../components/layout/Header';
 import { Sidebar } from '../components/layout/Sidebar';
 import { VideoCapture } from '../components/video/VideoCapture';
@@ -19,6 +19,10 @@ import { useAudioCapture } from '../hooks/useAudioCapture';
 import { useEmotionAnalysis } from '../hooks/useEmotionAnalysis';
 import { useEmotionAlerts } from '../hooks/useEmotionAlerts';
 import { useSessionStore } from '../hooks/useSessionStore';
+import type { SessionData } from '../lib/types';
+
+type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
 
 export default function HomePage() {
   const { isCapturing: videoActive, videoRef, start: startVideo, stop: stopVideo } = useVideoCapture();
@@ -26,16 +30,60 @@ export default function HomePage() {
   const { mergedScore, analyzeVoice, analyzeFace } = useEmotionAnalysis();
   const { alerts, latestAlert, addScore, clearAlerts } = useEmotionAlerts();
   const { isActive, startSession, endSession, addFrame } = useSessionStore();
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('loading');
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
 
   // 感情スコアが更新されたらアラート判定とフレーム蓄積
   useEffect(() => {
     if (!mergedScore || !isActive) return;
-    addScore(mergedScore);
+    const frameAlerts = addScore(mergedScore);
+    addFrame({
+      timestamp: Date.now(),
+      merged: mergedScore,
+      alerts: frameAlerts,
+    });
   }, [mergedScore, isActive, addScore]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadCurrentUser() {
+      try {
+        const response = await fetch('/api/auth/me');
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          setAuthStatus('authenticated');
+          return;
+        }
+
+        if (response.status === 401) {
+          setAuthStatus('unauthenticated');
+          return;
+        }
+
+        setAuthStatus('unauthenticated');
+      } catch {
+        if (!cancelled) {
+          setAuthStatus('unauthenticated');
+        }
+      }
+    }
+
+    void loadCurrentUser();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleStart = useCallback(async () => {
     startSession();
     clearAlerts();
+    setSaveStatus('idle');
     await startVideo((imageBase64) => {
       analyzeFace(imageBase64);
     });
@@ -44,15 +92,62 @@ export default function HomePage() {
     });
   }, [startSession, clearAlerts, startVideo, startAudio, analyzeFace, analyzeVoice]);
 
-  const handleStop = useCallback(() => {
+  const persistSession = useCallback(async (completedSession: SessionData) => {
+    setSaveStatus('saving');
+
+    try {
+      const response = await fetch('/api/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session: completedSession }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save session.');
+      }
+
+      setSaveStatus('success');
+    } catch {
+      setSaveStatus('error');
+    }
+  }, []);
+
+  const handleStop = useCallback(async () => {
     stopVideo();
     stopAudio();
-    endSession();
-  }, [stopVideo, stopAudio, endSession]);
+    const completedSession = endSession();
+
+    if (!completedSession) {
+      return;
+    }
+
+    if (authStatus !== 'authenticated') {
+      setSaveStatus('idle');
+      return;
+    }
+
+    await persistSession(completedSession);
+  }, [authStatus, endSession, persistSession, stopAudio, stopVideo]);
+
+  const sessionMessage =
+    saveStatus === 'saving'
+      ? 'セッションを保存中です'
+      : saveStatus === 'error'
+        ? 'セッションの保存に失敗しました'
+        : saveStatus === 'success'
+          ? 'セッションを保存しました'
+          : authStatus === 'loading'
+            ? '認証状態を確認中です'
+            : authStatus === 'authenticated'
+              ? 'ログイン中のみセッションを保存します'
+              : 'ログインするとセッションを保存できます';
 
   return (
     <div data-theme="emotion-dark" className="flex h-screen flex-col bg-base-100 text-base-content">
-      <Header isActive={isActive} onStart={handleStart} onStop={handleStop} />
+      <Header isActive={isActive} onStart={handleStart} onStop={() => void handleStop()} />
+      <div className="border-b border-el-border bg-base-200/60 px-4 py-2 text-sm text-el-muted">
+        {sessionMessage}
+      </div>
       <div className="flex flex-1 overflow-hidden">
         <Sidebar alerts={alerts} />
         <main className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 md:flex-row">

--- a/app/report/page.tsx
+++ b/app/report/page.tsx
@@ -5,36 +5,106 @@
  * セッション終了後に感情推移とアラート履歴を表示する
  */
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { useSessionStore } from '../../hooks/useSessionStore';
 import type { SessionData } from '../../lib/types';
 import { KpiCards } from '../../components/report/KpiCards';
 import { EmotionTimeline } from '../../components/report/EmotionTimeline';
 import { EmotionDonut } from '../../components/report/EmotionDonut';
 import { AlertLogTable } from '../../components/report/AlertLogTable';
 
+type ReportStatus = 'loading' | 'ready' | 'empty' | 'unauthenticated' | 'error';
+
 export default function ReportPage() {
-  const { session } = useSessionStore();
   const [data, setData] = useState<SessionData | null>(null);
+  const [status, setStatus] = useState<ReportStatus>('loading');
 
   useEffect(() => {
-    // Local storage または context から session を復元
-    if (session) {
-      setData(session);
-    } else {
-      // localStorage から取得を試みる
-      const stored = localStorage.getItem('session-data');
-      if (stored) {
-        try {
-          setData(JSON.parse(stored));
-        } catch {
-          setData(null);
+    let cancelled = false;
+
+    async function loadLatestSession() {
+      try {
+        const response = await fetch('/api/sessions/latest', { cache: 'no-store' });
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          const payload = (await response.json()) as { session: SessionData };
+          setData(payload.session);
+          setStatus('ready');
+          return;
+        }
+
+        if (response.status === 401) {
+          setStatus('unauthenticated');
+          return;
+        }
+
+        if (response.status === 404) {
+          setStatus('empty');
+          return;
+        }
+
+        setStatus('error');
+      } catch {
+        if (!cancelled) {
+          setStatus('error');
         }
       }
     }
-  }, [session]);
 
-  if (!data) {
+    void loadLatestSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === 'loading') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-3">
+            <h2 className="card-title text-lg">レポートを読み込み中です</h2>
+            <p className="text-sm text-el-muted">最新の保存済みセッションを取得しています</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'unauthenticated') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-4">
+            <h2 className="card-title text-lg">ログインするとレポートを表示できます</h2>
+            <p className="text-sm text-el-muted">保存済みセッションの閲覧にはログインが必要です</p>
+            <Link href="/login" className="btn btn-primary btn-sm">
+              ログインへ進む
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-3">
+            <h2 className="card-title text-lg">レポートの取得に失敗しました</h2>
+            <p className="text-sm text-el-muted">時間をおいて再度お試しください</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'empty' || !data) {
     return (
       <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
         <div className="card w-full max-w-md bg-base-200 shadow-xl">

--- a/hooks/useEmotionAlerts.ts
+++ b/hooks/useEmotionAlerts.ts
@@ -13,7 +13,7 @@ export interface UseEmotionAlertsReturn {
   /** 蓄積されたアラートリスト */
   alerts: EmotionAlert[];
   /** 感情スコアを渡してアラートを検出・追加する */
-  addScore: (score: EmotionScore) => void;
+  addScore: (score: EmotionScore) => EmotionAlert[];
   /** アラート履歴とクールダウン状態をリセットする */
   clearAlerts: () => void;
   /** 最後に追加されたアラート（なければ null） */
@@ -45,6 +45,8 @@ export function useEmotionAlerts(): UseEmotionAlertsReturn {
       });
       setAlerts((prev) => [...prev, ...filtered]);
     }
+
+    return filtered;
   }, []);
 
   const clearAlerts = useCallback(() => {


### PR DESCRIPTION
## 概要
- issue #20 に沿ってフロントエンドを認証済みセッション保存フローへ接続
- セッション終了時の保存、未ログイン時の表示、レポート画面の最新セッション取得を実装
- 先にテストを追加してから実装を進める

Closes #20