### PR TITLE
#27: Phase 1: Tauri プロジェクト初期セットアップ & Next.js 廃止

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ node_modules
 .DS_Store
 README.md
 docker-compose.yml
+target
+Cargo.lock
+.cargo

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,10 @@ dist
 .github/md/*
 .github/copilot-instructions.md
 .claude/CLAUDE.md
+
+# Tauri build artifacts
+src-tauri/target/
+src-tauri/Cargo.lock
+
+# macOS specific
+.DS_Store

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import App from '../src/App'
+import '@testing-library/jest-dom'
+
+describe('App コンポーネント', () => {
+  it('EmotionLens のタイトルが表示されること', () => {
+    render(<App />)
+    expect(screen.getByText('EmotionLens')).toBeInTheDocument()
+  })
+
+  it('カウンターボタンが存在すること', () => {
+    render(<App />)
+    const button = screen.getByRole('button', { name: /count is/i })
+    expect(button).toBeInTheDocument()
+  })
+})

--- a/__tests__/tauri-setup.test.ts
+++ b/__tests__/tauri-setup.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll } from '@jest/globals'
+import * as fs from 'fs'
+import * as path from 'path'
+
+describe('Tauri初期セットアップのテスト', () => {
+  describe('プロジェクト構造', () => {
+    it('src ディレクトリが存在すること', () => {
+      const srcPath = path.join(process.cwd(), 'src')
+      expect(fs.existsSync(srcPath)).toBe(true)
+    })
+
+    it('src-tauri ディレクトリが存在すること', () => {
+      const tauriPath = path.join(process.cwd(), 'src-tauri')
+      expect(fs.existsSync(tauriPath)).toBe(true)
+    })
+
+    it('src-tauri/src ディレクトリが存在すること', () => {
+      const tauriSrcPath = path.join(process.cwd(), 'src-tauri', 'src')
+      expect(fs.existsSync(tauriSrcPath)).toBe(true)
+    })
+  })
+
+  describe('設定ファイル', () => {
+    it('vite.config.ts が存在すること', () => {
+      const configPath = path.join(process.cwd(), 'vite.config.ts')
+      expect(fs.existsSync(configPath)).toBe(true)
+    })
+
+    it('tauri.conf.json が存在すること', () => {
+      const configPath = path.join(process.cwd(), 'src-tauri', 'tauri.conf.json')
+      expect(fs.existsSync(configPath)).toBe(true)
+    })
+
+    it('Cargo.toml が存在すること', () => {
+      const configPath = path.join(process.cwd(), 'src-tauri', 'Cargo.toml')
+      expect(fs.existsSync(configPath)).toBe(true)
+    })
+
+    it('tsconfig.json が存在すること', () => {
+      const configPath = path.join(process.cwd(), 'tsconfig.json')
+      expect(fs.existsSync(configPath)).toBe(true)
+    })
+  })
+
+  describe('フロントエンドファイル', () => {
+    it('index.html が存在すること', () => {
+      const indexPath = path.join(process.cwd(), 'index.html')
+      expect(fs.existsSync(indexPath)).toBe(true)
+    })
+
+    it('src/main.tsx が存在すること', () => {
+      const mainPath = path.join(process.cwd(), 'src', 'main.tsx')
+      expect(fs.existsSync(mainPath)).toBe(true)
+    })
+
+    it('src/App.tsx が存在すること', () => {
+      const appPath = path.join(process.cwd(), 'src', 'App.tsx')
+      expect(fs.existsSync(appPath)).toBe(true)
+    })
+
+    it('src/index.css が存在すること', () => {
+      const cssPath = path.join(process.cwd(), 'src', 'index.css')
+      expect(fs.existsSync(cssPath)).toBe(true)
+    })
+
+    it('src/App.css が存在すること', () => {
+      const cssPath = path.join(process.cwd(), 'src', 'App.css')
+      expect(fs.existsSync(cssPath)).toBe(true)
+    })
+  })
+
+  describe('Rustエントリポイント', () => {
+    it('src-tauri/src/main.rs が存在すること', () => {
+      const mainRsPath = path.join(process.cwd(), 'src-tauri', 'src', 'main.rs')
+      expect(fs.existsSync(mainRsPath)).toBe(true)
+    })
+
+    it('src-tauri/build.rs が存在すること', () => {
+      const buildRsPath = path.join(process.cwd(), 'src-tauri', 'build.rs')
+      expect(fs.existsSync(buildRsPath)).toBe(true)
+    })
+  })
+
+  describe('package.json の依存関係', () => {
+    let packageJson: any
+
+    beforeAll(() => {
+      const packagePath = path.join(process.cwd(), 'package.json')
+      const content = fs.readFileSync(packagePath, 'utf-8')
+      packageJson = JSON.parse(content)
+    })
+
+    it('Tauri APIがdevDependenciesに含まれること', () => {
+      expect(packageJson.devDependencies['@tauri-apps/api']).toBeDefined()
+    })
+
+    it('Tauri CLIがdevDependenciesに含まれること', () => {
+      expect(packageJson.devDependencies['@tauri-apps/cli']).toBeDefined()
+    })
+
+    it('ViteがdevDependenciesに含まれること', () => {
+      expect(packageJson.devDependencies.vite).toBeDefined()
+    })
+
+    it('@vitejs/plugin-reactがdevDependenciesに含まれること', () => {
+      expect(packageJson.devDependencies['@vitejs/plugin-react']).toBeDefined()
+    })
+
+    it('Next.jsがdependenciesから削除されていること', () => {
+      expect(packageJson.dependencies.next).toBeUndefined()
+    })
+
+    it('next-authがdependenciesから削除されていること', () => {
+      expect(packageJson.dependencies['next-auth']).toBeUndefined()
+    })
+
+    it('Reactが含まれていること', () => {
+      expect(packageJson.dependencies.react).toBeDefined()
+    })
+
+    it('React Domが含まれていること', () => {
+      expect(packageJson.dependencies['react-dom']).toBeDefined()
+    })
+  })
+
+  describe('tauri.conf.json の設定', () => {
+    let tauriConf: any
+
+    beforeAll(() => {
+      const configPath = path.join(process.cwd(), 'src-tauri', 'tauri.conf.json')
+      const content = fs.readFileSync(configPath, 'utf-8')
+      tauriConf = JSON.parse(content)
+    })
+
+    it('アプリ名が正しく設定されていること', () => {
+      expect(tauriConf.package.productName).toBe('EmotionLens')
+    })
+
+    it('ウィンドウタイトルが正しく設定されていること', () => {
+      expect(tauriConf.app.windows[0].title).toBe('EmotionLens')
+    })
+
+    it('ViteのdevUrlが設定されていること', () => {
+      expect(tauriConf.build.devUrl).toBeDefined()
+    })
+
+    it('frontendDistが設定されていること', () => {
+      expect(tauriConf.build.frontendDist).toBeDefined()
+    })
+  })
+
+  describe('Cargo.toml の設定', () => {
+    let cargoContent: string
+
+    beforeAll(() => {
+      const cargoPath = path.join(process.cwd(), 'src-tauri', 'Cargo.toml')
+      cargoContent = fs.readFileSync(cargoPath, 'utf-8')
+    })
+
+    it('パッケージ名が正しく設定されていること', () => {
+      expect(cargoContent).toContain('name = "emotion-lens"')
+    })
+
+    it('tauriが依存関係に含まれていること', () => {
+      expect(cargoContent).toContain('tauri')
+    })
+
+    it('serdeが依存関係に含まれていること', () => {
+      expect(cargoContent).toContain('serde')
+    })
+
+    it('tokioが依存関係に含まれていること', () => {
+      expect(cargoContent).toContain('tokio')
+    })
+  })
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     container_name: emotion-lens-dev
     ports:
       - '3000:3000'
+      - '8080:8080'
     volumes:
       - .:/app
       - /app/node_modules
       - /app/.next
+      - /app/target
+      - /root/.cargo
     depends_on:
       postgres:
         condition: service_healthy
@@ -18,6 +21,8 @@ services:
       - WATCHPACK_POLLING=true
       - CHOKIDAR_USEPOLLING=true
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/emotion_lens
+      - RUST_BACKTRACE=1
+      - CARGO_NET_OFFLINE=false
     env_file:
       - path: .env.local
         required: false

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -2,10 +2,38 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# Rust + Tauri 開発環境のシステムパッケージをインストール
+RUN apk add --no-cache \
+    build-base \
+    cairo-dev \
+    jpeg-dev \
+    pango-dev \
+    gif-dev \
+    pixman-dev \
+    libwebp-dev \
+    curl \
+    wget \
+    gcc \
+    g++ \
+    make \
+    python3 \
+    openssl-dev
+
+# Rust toolchain をインストール
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    chmod -R a+w /root/.cargo
+
+# Rust PATH を設定
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Tauri CLI をグローバルインストール
+RUN npm install -g @tauri-apps/cli
+
+# プロジェクト依存関係のインストール
 COPY package.json ./
 RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3000 8080
 CMD ["npm", "run", "dev"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EmotionLens</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,13 +2,17 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   roots: ['<rootDir>/__tests__'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }],
   },
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/src-tauri/'],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "emotion-lens",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
     "test": "jest",
     "docker:dev": "docker compose up --build --renew-anon-volumes",
     "docker:down": "docker compose down"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "next-auth": "^5.0.0-beta.25",
-    "pg": "^8.13.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "framer-motion": "^11.2.12",
@@ -24,15 +24,17 @@
     "daisyui": "^4.12.10"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
+    "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/cli": "^2.0.0",
     "@types/node": "^20.16.5",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^3.4.13",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20",
-    "esbuild": "^0.24.0",
-    "esbuild-loader": "^4.2.2",
+    "typescript": "^5.6.2",
+    "vite": "^5.3.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "@types/jest": "^29.5.13",
@@ -40,7 +42,6 @@
     "@testing-library/react": "^14.3.1",
     "@testing-library/jest-dom": "^6.4.6",
     "jest-environment-jsdom": "^29.7.0",
-    "@types/pg": "^8.11.10",
     "yaml": "^2.4.5"
   }
 }

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = []

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "emotion-lens"
+version = "0.1.0"
+description = "Real-time emotion detection from video conference participants"
+authors = ["EmotionLens Team"]
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2.0", features = [] }
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "2.0", features = ["shell-execute"] }
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+
+[profile.release]
+codegen-units = 1
+lto = true

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  tauri_build::build()
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,8 @@
+// Prevents additional console window on Windows in release, DO NOT REMOVE!!
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run dev",
+    "devUrl": "http://localhost:5173",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "fullscreen": false,
+        "height": 900,
+        "resizable": true,
+        "title": "EmotionLens",
+        "width": 1200
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "package": {
+    "productName": "EmotionLens",
+    "version": "0.1.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,38 @@
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+.logo {
+  height: 6em;
+  padding: 1.5em;
+  will-change: filter;
+  transition: filter 300ms;
+}
+
+.logo:hover {
+  filter: drop-shadow(0 0 2em #646cffaa);
+}
+
+.logo.react:hover {
+  filter: drop-shadow(0 0 2em #61dafbaa);
+}
+
+.card {
+  padding: 2em;
+}
+
+.read-the-docs {
+  color: #888;
+}
+
+.container {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import './App.css'
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="container">
+      <h1>EmotionLens</h1>
+      <div className="card">
+        <button onClick={() => setCount((count) => count + 1)}>
+          count is {count}
+        </button>
+        <p>
+          Edit <code>src/App.tsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className="read-the-docs">
+        Click on the Tauri, Vite, and React logos to learn more
+      </p>
+    </div>
+  )
+}
+
+export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,51 @@
+:root {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: #646cff;
+  text-decoration: inherit;
+}
+
+a:hover {
+  color: #535bf2;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+
+button:hover {
+  border-color: #646cff;
+}
+
+button:active {
+  border-color: #646cff;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,25 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "allowJs": false,
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
     "skipLibCheck": true,
     "strict": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src", "src-tauri/src"],
+  "exclude": ["node_modules", "dist", "build"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+  // Vite options tailored for Tauri to prevent too many requests
+  server: {
+    strictPort: true,
+  },
+  build: {
+    target: ['es2021', 'chrome100', 'safari13'],
+    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
+    sourcemap: !!process.env.TAURI_DEBUG,
+  },
+})


### PR DESCRIPTION
## 概要
Next.js / Vercel ベースのアーキテクチャを Tauri + React (SPA) + Rust に完全移行するための初期セットアップを行う。

## タスク
- [ ] `create-tauri-app` で Tauri v2 プロジェクトを新規生成（フロントエンドは React + TypeScript + Vite）
- [ ] 既存の `components/`, `hooks/`, `lib/`, `constants/` を新プロジェクトへコピー
- [ ] `next.config.js`, `app/`, `pages/` などの Next.js 固有ファイルを削除
- [ ] `package.json` の依存関係を整理（next, react-dom SSR 系を除去）
- [ ] `tailwind.config.ts` / `postcss.config.js` を Vite ビルドに対応
- [ ] `tsconfig.json` を Tauri/Vite 用に更新
- [ ] `src-tauri/tauri.conf.json` の基本設定（アプリ名・ウィンドウサイズ等）
- [ ] `Cargo.toml` に最低限の依存クレートを追加（tauri, serde, tokio）
- [ ] `npm run tauri dev` でブランク画面が起動することを確認

## 完了条件
- Tauri dev モードで React 画面が表示される
- ビルドエラーがない

Closes #27