### PR TITLE
#28: React SPA ルーティング実装

### DIFF
--- a/__tests__/layout/RootLayout.test.tsx
+++ b/__tests__/layout/RootLayout.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * RootLayout コンポーネントのテスト
+ * SPA レイアウトの基本構造と共通要素の確認
+ */
+
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import RootLayout from '../../src/layout/RootLayout';
+
+describe('RootLayout コンポーネント', () => {
+  it('RootLayout が正常に描画される', () => {
+    render(
+      <BrowserRouter>
+        <RootLayout>
+          <div>テストコンテンツ</div>
+        </RootLayout>
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+  });
+
+  it('data-theme="emotion-dark" 属性が設定される', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <RootLayout>
+          <div>テストコンテンツ</div>
+        </RootLayout>
+      </BrowserRouter>
+    );
+
+    const rootElement = container.querySelector('[data-theme="emotion-dark"]');
+    expect(rootElement).toBeInTheDocument();
+  });
+
+  it('min-h-screen クラスが適用される', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <RootLayout>
+          <div>テストコンテンツ</div>
+        </RootLayout>
+      </BrowserRouter>
+    );
+
+    const layoutElement = container.querySelector('.min-h-screen');
+    expect(layoutElement).toBeInTheDocument();
+  });
+
+  it('Tailwind DaisyUI テーマクラスが適用される', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <RootLayout>
+          <div>テストコンテンツ</div>
+        </RootLayout>
+      </BrowserRouter>
+    );
+
+    const layoutElement = container.querySelector('.bg-base-100');
+    expect(layoutElement).toBeInTheDocument();
+  });
+});

--- a/__tests__/routing/routing.test.tsx
+++ b/__tests__/routing/routing.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * React Router SPA ルーティング統合テスト
+ * ルーティング設定とページナビゲーションの動作確認
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import App from '../../src/App';
+
+// fetch モックの設定
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+// 各 Hooks をモック
+jest.mock('../../hooks/useVideoCapture', () => ({
+  useVideoCapture: () => ({
+    isCapturing: false,
+    error: null,
+    videoRef: { current: null },
+    start: jest.fn(),
+    stop: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useAudioCapture', () => ({
+  useAudioCapture: () => ({
+    isCapturing: false,
+    error: null,
+    start: jest.fn(),
+    stop: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useEmotionAnalysis', () => ({
+  useEmotionAnalysis: () => ({
+    voiceScore: null,
+    faceScore: null,
+    mergedScore: null,
+    isAnalyzing: false,
+    error: null,
+    analyzeVoice: jest.fn(),
+    analyzeFace: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useEmotionAlerts', () => ({
+  useEmotionAlerts: () => ({
+    alerts: [],
+    latestAlert: null,
+    addScore: jest.fn(),
+    clearAlerts: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useSessionStore', () => ({
+  useSessionStore: () => ({
+    session: null,
+    isActive: false,
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    addFrame: jest.fn(),
+  }),
+}));
+
+describe('React Router SPA ルーティング', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('/ ルートでホームページが描画される', () => {
+    mockFetch.mockImplementation(() => new Promise(() => undefined));
+
+    render(
+      <BrowserRouter initialEntries={['/']}>
+        <App />
+      </BrowserRouter>
+    );
+
+    // ホームページに特有の要素（Header など）が表示されることを確認
+    expect(screen.getByText('EmotionLens')).toBeInTheDocument();
+  });
+
+  it('ホームページに開始ボタンが表示される', () => {
+    mockFetch.mockImplementation(() => new Promise(() => undefined));
+
+    render(
+      <BrowserRouter initialEntries={['/']}>
+        <App />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /開始/ })).toBeInTheDocument();
+  });
+
+  it('/report ルートでレポートページが描画される', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(200, { session: {} }));
+
+    render(
+      <BrowserRouter initialEntries={['/report']}>
+        <App />
+      </BrowserRouter>
+    );
+
+    // レポートページが読み込み中状態を表示
+    await waitFor(() => {
+      expect(screen.getByText('レポート')).toBeInTheDocument();
+    });
+  });
+
+  it('サイドバーにアラート履歴が表示される', () => {
+    mockFetch.mockImplementation(() => new Promise(() => undefined));
+
+    render(
+      <BrowserRouter initialEntries={['/']}>
+        <App />
+      </BrowserRouter>
+    );
+
+    // Sidebar コンポーネントが描画されることを確認
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-router-dom": "^6.26.0",
     "framer-motion": "^11.2.12",
     "recharts": "^2.12.7",
     "@mediapipe/face_mesh": "^0.4.1633559619",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,23 @@
-import { useState } from 'react'
-import './App.css'
+/**
+ * EmotionLens メインアプリケーション
+ * React Router SPA ルーティング設定
+ */
+
+import { Routes, Route } from 'react-router-dom';
+import RootLayout from './layout/RootLayout';
+import HomePage from './pages/HomePage';
+import ReportPage from './pages/ReportPage';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <div className="container">
-      <h1>EmotionLens</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Tauri, Vite, and React logos to learn more
-      </p>
-    </div>
-  )
+    <RootLayout>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/report" element={<ReportPage />} />
+      </Routes>
+    </RootLayout>
+  );
 }
 
-export default App
+export default App;
+

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,0 +1,16 @@
+/**
+ * RootLayout コンポーネント
+ * SPA レイアウトの基本構造を定義
+ */
+
+type RootLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <div data-theme="emotion-dark" className="min-h-screen bg-base-100 text-base-content">
+      {children}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )
+

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,171 @@
+/**
+ * ホームページ
+ * メイン画面：映像プレビュー・感情パネル・アラート通知を統合
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Header } from '../components/layout/Header';
+import { Sidebar } from '../components/layout/Sidebar';
+import { VideoCapture } from '../components/video/VideoCapture';
+import { FaceLandmarkOverlay } from '../components/video/FaceLandmarkOverlay';
+import { EmotionBadge } from '../components/video/EmotionBadge';
+import { EmotionAlertBanner } from '../components/emotion/EmotionAlert';
+import { EmotionPanel } from '../components/emotion/EmotionPanel';
+import { AlertHistory } from '../components/emotion/AlertHistory';
+import { useVideoCapture } from '../hooks/useVideoCapture';
+import { useAudioCapture } from '../hooks/useAudioCapture';
+import { useEmotionAnalysis } from '../hooks/useEmotionAnalysis';
+import { useEmotionAlerts } from '../hooks/useEmotionAlerts';
+import { useSessionStore } from '../hooks/useSessionStore';
+import type { SessionData } from '../lib/types';
+
+type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
+
+export default function HomePage() {
+  const { isCapturing: videoActive, videoRef, start: startVideo, stop: stopVideo } = useVideoCapture();
+  const { isCapturing: audioActive, start: startAudio, stop: stopAudio } = useAudioCapture();
+  const { mergedScore, analyzeVoice, analyzeFace } = useEmotionAnalysis();
+  const { alerts, latestAlert, addScore, clearAlerts } = useEmotionAlerts();
+  const { isActive, startSession, endSession, addFrame } = useSessionStore();
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('loading');
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  // 感情スコアが更新されたらアラート判定とフレーム蓄積
+  useEffect(() => {
+    if (!mergedScore || !isActive) return;
+    const frameAlerts = addScore(mergedScore);
+    addFrame({
+      timestamp: Date.now(),
+      merged: mergedScore,
+      alerts: frameAlerts,
+    });
+  }, [mergedScore, isActive, addScore]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadCurrentUser() {
+      try {
+        const response = await fetch('/api/auth/me');
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          setAuthStatus('authenticated');
+          return;
+        }
+
+        if (response.status === 401) {
+          setAuthStatus('unauthenticated');
+          return;
+        }
+
+        setAuthStatus('unauthenticated');
+      } catch {
+        if (!cancelled) {
+          setAuthStatus('unauthenticated');
+        }
+      }
+    }
+
+    void loadCurrentUser();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleStart = useCallback(async () => {
+    startSession();
+    clearAlerts();
+    setSaveStatus('idle');
+    await startVideo((imageBase64) => {
+      analyzeFace(imageBase64);
+    });
+    await startAudio((buffer) => {
+      analyzeVoice(buffer);
+    });
+  }, [startSession, clearAlerts, startVideo, startAudio, analyzeFace, analyzeVoice]);
+
+  const persistSession = useCallback(async (completedSession: SessionData) => {
+    setSaveStatus('saving');
+
+    try {
+      const response = await fetch('/api/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session: completedSession }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save session.');
+      }
+
+      setSaveStatus('success');
+    } catch {
+      setSaveStatus('error');
+    }
+  }, []);
+
+  const handleStop = useCallback(async () => {
+    stopVideo();
+    stopAudio();
+    const completedSession = endSession();
+
+    if (!completedSession) {
+      return;
+    }
+
+    if (authStatus !== 'authenticated') {
+      setSaveStatus('idle');
+      return;
+    }
+
+    await persistSession(completedSession);
+  }, [authStatus, endSession, persistSession, stopAudio, stopVideo]);
+
+  const sessionMessage =
+    saveStatus === 'saving'
+      ? 'セッションを保存中です'
+      : saveStatus === 'error'
+        ? 'セッションの保存に失敗しました'
+        : saveStatus === 'success'
+          ? 'セッションを保存しました'
+          : authStatus === 'loading'
+            ? '認証状態を確認中です'
+            : authStatus === 'authenticated'
+              ? 'ログイン中のみセッションを保存します'
+              : 'ログインするとセッションを保存できます';
+
+  return (
+    <div data-theme="emotion-dark" className="flex h-screen flex-col bg-base-100 text-base-content">
+      <Header isActive={isActive} onStart={handleStart} onStop={() => void handleStop()} authStatus={authStatus} />
+      <div className="border-b border-el-border bg-base-200/60 px-4 py-2 text-sm text-el-muted">
+        {sessionMessage}
+      </div>
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar alerts={alerts} />
+        <main className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 md:flex-row">
+          {/* 左: 映像エリア */}
+          <section className="flex flex-col gap-3 md:w-1/2">
+            <div className="relative">
+              <VideoCapture isActive={videoActive} videoRef={videoRef}>
+                <EmotionBadge score={mergedScore} />
+              </VideoCapture>
+              <FaceLandmarkOverlay videoRef={videoRef} isActive={videoActive} />
+            </div>
+            {latestAlert && <EmotionAlertBanner alert={latestAlert} />}
+          </section>
+          {/* 右: スコア・履歴エリア */}
+          <section className="flex flex-col gap-4 md:w-1/2">
+            <EmotionPanel score={mergedScore} />
+            <AlertHistory alerts={alerts} />
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -1,0 +1,160 @@
+/**
+ * レポートページ
+ * セッション終了後に感情推移とアラート履歴を表示
+ */
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { SessionData } from '../lib/types';
+import { KpiCards } from '../components/report/KpiCards';
+import { EmotionTimeline } from '../components/report/EmotionTimeline';
+import { EmotionDonut } from '../components/report/EmotionDonut';
+import { AlertLogTable } from '../components/report/AlertLogTable';
+
+type ReportStatus = 'loading' | 'ready' | 'empty' | 'unauthenticated' | 'error';
+
+export default function ReportPage() {
+  const [data, setData] = useState<SessionData | null>(null);
+  const [status, setStatus] = useState<ReportStatus>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadLatestSession() {
+      try {
+        const response = await fetch('/api/sessions/latest', { cache: 'no-store' } as RequestInit);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          const payload = (await response.json()) as { session: SessionData };
+          setData(payload.session);
+          setStatus('ready');
+          return;
+        }
+
+        if (response.status === 401) {
+          setStatus('unauthenticated');
+          return;
+        }
+
+        if (response.status === 404) {
+          setStatus('empty');
+          return;
+        }
+
+        setStatus('error');
+      } catch {
+        if (!cancelled) {
+          setStatus('error');
+        }
+      }
+    }
+
+    void loadLatestSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === 'loading') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-3">
+            <h2 className="card-title text-lg">レポート</h2>
+            <p className="text-sm text-el-muted">最新の保存済みセッションを取得しています</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'unauthenticated') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-4">
+            <h2 className="card-title text-lg">ログインするとレポートを表示できます</h2>
+            <p className="text-sm text-el-muted">保存済みセッションの閲覧にはログインが必要です</p>
+            <Link to="/login" className="btn btn-primary btn-sm">
+              ログインへ進む
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-3">
+            <h2 className="card-title text-lg">レポートの取得に失敗しました</h2>
+            <p className="text-sm text-el-muted">時間をおいて再度お試しください</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'empty' || !data) {
+    return (
+      <div data-theme="emotion-dark" className="flex min-h-screen flex-col items-center justify-center bg-base-100">
+        <div className="card w-full max-w-md bg-base-200 shadow-xl">
+          <div className="card-body items-center text-center gap-3">
+            <h2 className="card-title text-lg">レポートデータなし</h2>
+            <p className="text-sm text-el-muted">
+              セッションを完了してから、レポート画面にアクセスしてください
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme="emotion-dark" className="min-h-screen bg-base-100 p-4 text-base-content">
+      <div className="mx-auto max-w-6xl space-y-6">
+        {/* タイトル */}
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">セッションレポート</h1>
+          <p className="text-sm text-el-muted">
+            {new Date(data.startedAt).toLocaleString('ja-JP')}
+          </p>
+        </div>
+
+        {/* KPI カード */}
+        <section className="card card-body bg-base-200 shadow-lg p-4">
+          <h2 className="text-lg font-semibold mb-3">主要指標</h2>
+          <KpiCards session={data} />
+        </section>
+
+        {/* グラフエリア */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {/* 感情時系列 */}
+          <section className="card card-body bg-base-200 shadow-lg p-4">
+            <h2 className="text-lg font-semibold mb-3">感情の推移</h2>
+            <EmotionTimeline session={data} />
+          </section>
+
+          {/* ドーナツチャート */}
+          <section className="card card-body bg-base-200 shadow-lg p-4">
+            <h2 className="text-lg font-semibold mb-3">感情の割合</h2>
+            <EmotionDonut session={data} />
+          </section>
+        </div>
+
+        {/* アラートログテーブル */}
+        <section className="card card-body bg-base-200 shadow-lg p-4">
+          <h2 className="text-lg font-semibold mb-3">アラートログ</h2>
+          <AlertLogTable session={data} />
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Tauri SPA 環境への React Router ルーティング対応。Next.js App Router を撤去し、React Router による宣言的ルーティングを実装。

## 実装内容

- react-router-dom 追加
- RootLayout コンポーネント作成
- HomePage / ReportPage コンポーネント実装
- App.tsx にルーティング設定
- ルーティング統合テスト作成

## 完了条件

- npm test で全テスト通過
- npm run build で型エラーなし

Closes #28