### PR TITLE
#31: SQLite セッション永続化

### DIFF
--- a/hooks/useSessionPersistence.ts
+++ b/hooks/useSessionPersistence.ts
@@ -1,0 +1,83 @@
+import { useState, useCallback } from 'react';
+import * as db from '@/lib/database';
+
+export interface UseSessionPersistenceReturn {
+  sessions: db.SessionRecord[];
+  loading: boolean;
+  error: string | null;
+  saveSession: (emotionData: string, notes: string) => Promise<void>;
+  loadAllSessions: () => Promise<void>;
+  deleteSession: (id: string) => Promise<void>;
+}
+
+/**
+ * セッション永続化を管理する React Hooks
+ */
+export function useSessionPersistence(): UseSessionPersistenceReturn {
+  const [sessions, setSessions] = useState<db.SessionRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * セッション記録を保存
+   */
+  const saveSession = useCallback(
+    async (emotionData: string, notes: string) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const newSession = await db.saveSession(emotionData, notes);
+        setSessions((prev) => [newSession, ...prev]);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'セッション保存に失敗しました';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  /**
+   * すべてのセッション記録を読み込み
+   */
+  const loadAllSessions = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const loadedSessions = await db.loadSessions();
+      setSessions(loadedSessions);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'セッション読み込みに失敗しました';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * セッション記録を削除
+   */
+  const deleteSession = useCallback(async (id: string) => {
+    try {
+      setLoading(true);
+      setError(null);
+      await db.deleteSession(id);
+      setSessions((prev) => prev.filter((s) => s.id !== id));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'セッション削除に失敗しました';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    sessions,
+    loading,
+    error,
+    saveSession,
+    loadAllSessions,
+    deleteSession,
+  };
+}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,0 +1,35 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface SessionRecord {
+  id: string;
+  timestamp: string;
+  emotion_data: string;
+  notes: string;
+}
+
+/**
+ * セッション記録を保存
+ */
+export async function saveSession(
+  emotionData: string,
+  notes: string
+): Promise<SessionRecord> {
+  return invoke<SessionRecord>('save_session', {
+    emotion_data: emotionData,
+    notes,
+  });
+}
+
+/**
+ * すべてのセッション記録を読み込み
+ */
+export async function loadSessions(): Promise<SessionRecord[]> {
+  return invoke<SessionRecord[]>('load_sessions');
+}
+
+/**
+ * セッション記録を削除
+ */
+export async function deleteSession(id: string): Promise<void> {
+  return invoke<void>('delete_session', { id });
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,8 @@ reqwest = { version = "0.12", features = ["json"] }
 base64 = "0.22"
 active-win-pos-rs = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
+uuid = { version = "1.6", features = ["v4", "serde"] }
 
 [dev-dependencies]
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,0 +1,104 @@
+use rusqlite::{Connection, Result as SqliteResult, params};
+use serde::{Serialize, Deserialize};
+use std::path::PathBuf;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecord {
+    pub id: String,
+    pub timestamp: String,
+    pub emotion_data: String,
+    pub notes: String,
+}
+
+/// SQLite データベース管理構造体
+pub struct Database {
+    db_path: PathBuf,
+}
+
+impl Database {
+    /// データベースインスタンスを作成
+    pub fn new(db_path: PathBuf) -> Self {
+        Database { db_path }
+    }
+
+    /// SQLite スキーマを初期化
+    pub fn initialize_database(&self) -> SqliteResult<()> {
+        let conn = Connection::open(&self.db_path)?;
+
+        // セッション記録テーブルを作成
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                emotion_data TEXT NOT NULL,
+                notes TEXT NOT NULL
+            )",
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// セッション記録を保存
+    pub fn save_session(
+        &self,
+        emotion_data: String,
+        notes: String,
+    ) -> SqliteResult<SessionRecord> {
+        let conn = Connection::open(&self.db_path)?;
+
+        let id = Uuid::new_v4().to_string();
+        let timestamp = Utc::now().to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO sessions (id, timestamp, emotion_data, notes) VALUES (?1, ?2, ?3, ?4)",
+            params![&id, &timestamp, &emotion_data, &notes],
+        )?;
+
+        Ok(SessionRecord {
+            id,
+            timestamp,
+            emotion_data,
+            notes,
+        })
+    }
+
+    /// すべてのセッション記録を読み込み
+    pub fn load_sessions(&self) -> SqliteResult<Vec<SessionRecord>> {
+        let conn = Connection::open(&self.db_path)?;
+
+        let mut stmt = conn.prepare(
+            "SELECT id, timestamp, emotion_data, notes FROM sessions ORDER BY timestamp DESC"
+        )?;
+
+        let sessions = stmt.query_map([], |row| {
+            Ok(SessionRecord {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                emotion_data: row.get(2)?,
+                notes: row.get(3)?,
+            })
+        })?;
+
+        let mut result = Vec::new();
+        for session in sessions {
+            result.push(session?);
+        }
+
+        Ok(result)
+    }
+
+    /// セッション記録を削除
+    pub fn delete_session(&self, id: String) -> SqliteResult<()> {
+        let conn = Connection::open(&self.db_path)?;
+
+        conn.execute(
+            "DELETE FROM sessions WHERE id = ?1",
+            params![&id],
+        )?;
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,18 +3,64 @@
 
 mod hume;
 mod window_monitor;
+mod database;
 
 use window_monitor::WindowMonitorState;
+use database::{Database, SessionRecord};
+use std::sync::Mutex;
+use tauri::State;
+
+// Tauri コマンド: セッション記録を保存
+#[tauri::command]
+fn save_session(
+    db: State<Mutex<Database>>,
+    emotion_data: String,
+    notes: String,
+) -> Result<SessionRecord, String> {
+    let database = db.lock().map_err(|e| e.to_string())?;
+    database
+        .save_session(emotion_data, notes)
+        .map_err(|e| e.to_string())
+}
+
+// Tauri コマンド: すべてのセッション記録を読み込み
+#[tauri::command]
+fn load_sessions(db: State<Mutex<Database>>) -> Result<Vec<SessionRecord>, String> {
+    let database = db.lock().map_err(|e| e.to_string())?;
+    database.load_sessions().map_err(|e| e.to_string())
+}
+
+// Tauri コマンド: セッション記録を削除
+#[tauri::command]
+fn delete_session(db: State<Mutex<Database>>, id: String) -> Result<(), String> {
+    let database = db.lock().map_err(|e| e.to_string())?;
+    database.delete_session(id).map_err(|e| e.to_string())
+}
 
 fn main() {
   let monitor_state = WindowMonitorState::default();
 
+  // アプリケーション データディレクトリを取得
+  let app_dir = tauri::api::path::app_data_dir(&Default::default())
+    .expect("Failed to get app data dir");
+  let db_path = app_dir.join("sessions.db");
+
+  // データベースを初期化
+  let database = Database::new(db_path);
+  database
+    .initialize_database()
+    .expect("Failed to initialize database");
+
   tauri::Builder::default()
     .manage(monitor_state)
+    .manage(Mutex::new(database))
     .invoke_handler(tauri::generate_handler![
       hume::analyze_voice,
       hume::analyze_face,
       window_monitor::get_active_window,
+      save_session,
+      load_sessions,
+      delete_session,
     ])
     .setup(|app| {
       let app_handle = app.handle().clone();


### PR DESCRIPTION
## 概要

Tauri Rust 側に SQLite を統合し、感情解析セッション データの永続化を実装。

## 実装内容

- src-tauri/src/database.rs: SessionRecord 構造体と CRUD Operations
- Commands: save_session(), load_sessions(), delete_session()
- rusqlite と uuid 依存を Cargo.toml 追加
- lib/database.ts TypeScript ラッパー
- hooks/useSessionPersistence.ts React Hook

## 完了条件

- npm run tauri:dev でセッション保存・読み込み確認
- SQLite ファイルが .tauri/ に生成

Closes #31